### PR TITLE
V0.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /target
 *.db
 *.png
+*.sqlite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+# Changelog
+
+## [0.2.0] - 2025-09-xx
+### Added
+- Creation of a configuration file in the user home (depending on platform) with:
+    - DB filename
+    - Default working position (`A`)
+- New column `position` in SQLite DB to identify the working position of the day:
+    - `O` = Office
+    - `R` = Remote
+- New options for `add` command:
+    - `--pos` add the working position of the day, O = Office, R = Remote
+    - `--in` add the start hour of work
+    - `--lunch` add the duration of lunch
+    - `--out` add the end hour of work
+- Added global option `--db` to specify:
+    - a DB name (created under rTimelog config directory)
+    - or an absolute DB path
+- Added a message when the DB is empty (`⚠️ No recorded sessions found`)
+
+### Changed
+- Reorganized the output of the `list` command
+- Updated integration tests for new DB column `position`
+- Updated the logic for opening the connection to the DB file
+- Updated integration tests to use `--db` option
+
+### Notes
+- Previous intermediate changes introduced `--name` and config file handling,
+  but they have been replaced by the new global `--db` approach for consistency.
+
+---
+
 ## [v0.1.2] - 2025-09-12
 ### Added
 - Added functionality to search records by year (`yyyy`) or year-month (`yyyy-mm`) using option `--period`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,6 +71,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,6 +97,17 @@ name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+
+[[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -161,6 +197,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,6 +225,15 @@ name = "find-msvc-tools"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "foldhash"
@@ -272,6 +329,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,6 +368,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,10 +419,41 @@ dependencies = [
 name = "r_timelog"
 version = "0.1.5"
 dependencies = [
+ "assert_cmd",
  "chrono",
  "clap",
+ "predicates",
  "rusqlite",
 ]
+
+[[package]]
+name = "regex"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "rusqlite"
@@ -344,6 +474,35 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "serde"
+version = "1.0.220"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceecad4c782e936ac90ecfd6b56532322e3262b14320abf30ce89a92ffdbfe22"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.220"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddba47394f3b862d6ff6efdbd26ca4673e3566a307880a0ffb98f274bbe0ec32"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.220"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60e1f3b1761e96def5ec6d04a6e7421c0404fa3cf5c0155f1e2848fae3d8cc08"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "shlex"
@@ -375,6 +534,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,6 +556,15 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,10 +296,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
@@ -424,6 +446,8 @@ dependencies = [
  "clap",
  "predicates",
  "rusqlite",
+ "serde",
+ "serde_yaml",
 ]
 
 [[package]]
@@ -476,32 +500,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "serde"
-version = "1.0.220"
+name = "ryu"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceecad4c782e936ac90ecfd6b56532322e3262b14320abf30ce89a92ffdbfe22"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "serde"
+version = "1.0.223"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a505d71960adde88e293da5cb5eda57093379f64e61cf77bf0e6a63af07a7bac"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
 name = "serde_core"
-version = "1.0.220"
+version = "1.0.223"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddba47394f3b862d6ff6efdbd26ca4673e3566a307880a0ffb98f274bbe0ec32"
+checksum = "20f57cbd357666aa7b3ac84a90b4ea328f1d4ddb6772b430caa5d9e1309bb9e9"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.220"
+version = "1.0.223"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60e1f3b1761e96def5ec6d04a6e7421c0404fa3cf5c0155f1e2848fae3d8cc08"
+checksum = "3d428d07faf17e306e699ec1e91996e5a165ba5d6bce5b5155173e91a8a01a56"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -544,6 +588,12 @@ name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "r_timelog"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "r_timelog"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r_timelog"
-version = "0.1.2"
+version = "0.1.5"
 edition = "2024"
 authors = ["Umpire274 <umpire274@gmail.com>"]
 description = "A simple cross-platform CLI tool to track working hours, lunch breaks, and calculate surplus time"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,5 @@ chrono = "0.4.42"
 clap = { version = "4.5.47", features = ["derive"] }
 predicates = "3.1.3"
 assert_cmd = "2.0.17"
+serde = { version = "1.0.223", features = ["derive"] }
+serde_yaml = "0.9.33"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,5 @@ path = "src/main.rs"
 rusqlite = { version = "0.37.0", features = ["bundled"] }
 chrono = "0.4.42"
 clap = { version = "4.5.47", features = ["derive"] }
+predicates = "3.1.3"
+assert_cmd = "2.0.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r_timelog"
-version = "0.1.5"
+version = "0.2.0"
 edition = "2024"
 authors = ["Umpire274 <umpire274@gmail.com>"]
 description = "A simple cross-platform CLI tool to track working hours, lunch breaks, and calculate surplus time"

--- a/README.md
+++ b/README.md
@@ -4,47 +4,97 @@
 [![Latest Release](https://img.shields.io/github/v/release/umpire274/rTimelog)](https://github.com/umpire274/rTimelog/releases)
 [![codecov](https://codecov.io/gh/umpire274/rTimelog/branch/main/graph/badge.svg?token=5fb9648b-1dd5-46d2-8130-3916505ef4a3)](https://codecov.io/gh/umpire274/rTimelog)
 
-`rTimelog` is a simple, cross-platform **command-line tool** written in Rust that helps you track your working hours, lunch breaks, expected exit times, and surplus work time.
+`rTimelog` is a simple, cross-platform **command-line tool** written in Rust to track daily working sessions, including working position, start and end times, and lunch breaks.  
+The tool calculates the expected exit time and the surplus of worked minutes.
 
 ---
 
 ## ✨ Features
 
-- Add daily work sessions with:
-  - Date (`YYYY-MM-DD`)
-  - Start time (`HH:MM`)
-  - Lunch break duration (min. **30 min**, max. **90 min**)
-  - End time (`HH:MM`)
-- Automatically calculate:
-  - **Expected exit time** (8h work + lunch break, with lunch normalization rules)
-  - **Surplus** (actual exit – expected exit, shows `+` for positive values)
-- Query sessions:
-  - All sessions
-  - By year (`--period 2025`)
-  - By year and month (`--period 2025-09`)
-- Store data in a lightweight **SQLite database** (embedded, no server required)
-- Fully cross-platform: Windows, Linux, macOS
+- Store and manage working sessions in a SQLite database
+- Track working position:
+  - `O` = Office
+  - `R` = Remote
+- Add or update sessions with flags:
+  - `--pos` working position
+  - `--in` start time (HH:MM)
+  - `--lunch` lunch duration in minutes (0–90)
+  - `--out` end time (HH:MM)
+- Automatic normalization of lunch time if working from the Office:
+  - Minimum 30 minutes
+  - Maximum 90 minutes
+  - If less than 30 minutes are taken, the missing time is added to the expected exit time
+- Global option `--db` to choose the SQLite database file:
+  - If a **filename** is provided, it will be placed under the rTimelog config directory:
+    - Linux/macOS: `$HOME/.rtimelog/<filename>`
+    - Windows: `%APPDATA%\rtimelog\<filename>`
+  - If an **absolute path** is provided, that file will be used directly
+- If no sessions are stored, `rtimelog list` prints:  
+  ```
+  ⚠️ No recorded sessions found
+  ```
 
 ---
 
-## 📦 Installation
+## 🚀 Usage
 
-### Prebuilt binaries
-Download the latest release from the [GitHub Releases](https://github.com/umpire274/rTimelog/releases).  
-Available for:
-- **Linux** (`.tar.gz`)
-- **macOS Intel** (`.tar.gz`)
-- **macOS Apple Silicon** (`.tar.gz`)
-- **Windows** (`.zip`)
+### Initialize the database
 
-Each package includes:
-- The compiled binary
-- `README.md`
-- `LICENSE`
-- `CHANGELOG.md`
+```bash
+# Default path (~/.rtimelog/rtimelog.sqlite or %APPDATA%\rtimelog\rtimelog.sqlite)
+rtimelog init
 
-### From source
-Clone this repository and build with Cargo:
+# Initialize with custom DB name inside config dir
+rtimelog --db custom.sqlite init
+
+# Initialize with absolute path
+rtimelog --db /tmp/test.sqlite init
+```
+
+### Add sessions
+
+```bash
+# Add a complete session
+rtimelog add 2025-09-12 --pos O --in 09:00 --lunch 45 --out 17:30
+
+# Add only the start time
+rtimelog add 2025-09-12 --pos O --in 09:00
+
+# Add the lunch break later
+rtimelog add 2025-09-12 --lunch 45
+
+# Add the exit time
+rtimelog add 2025-09-12 --out 17:30
+```
+
+### List sessions
+
+```bash
+# List all sessions
+rtimelog list
+
+# List sessions for a specific year
+rtimelog list --period 2025
+
+# List sessions for a specific year and month
+rtimelog list --period 2025-09
+```
+
+---
+
+## 📊 Example output
+
+```
+📅 Saved sessions for September 2025:
+  1: 2025-09-12 | Pos O | Start 09:00 | Lunch 45 min | End 17:30 | Expected 18:45 | Surplus -75 min
+  2: 2025-09-13 | Pos R | Start 08:30 | Lunch 60 min | End 17:45 | Expected 17:30 | Surplus +15 min
+```
+
+---
+
+## 🛠️ Build
+
+Clone the repository and build with Cargo:
 
 ```bash
 git clone https://github.com/umpire274/rTimelog.git
@@ -52,74 +102,11 @@ cd rTimelog
 cargo build --release
 ```
 
-The compiled binary will be available in:
-
-- `target/release/rtimelog` (Linux/macOS)
-- `target\release\rtimelog.exe` (Windows)
+The binary will be in `target/release/rtimelog`.
 
 ---
 
-## 🚀 Usage
+## 📄 License
 
-Initialize the database:
-
-```bash
-rtimelog init
-```
-
-Add a work session:
-
-```bash
-rtimelog add 2025-09-12 09:00 45 17:30
-```
-
-List all sessions:
-
-```bash
-rtimelog list
-```
-
-Filter by year:
-
-```bash
-rtimelog list --period 2025
-```
-
-Filter by year + month:
-
-```bash
-rtimelog list --period 2025-09
-```
-
-Example output:
-
-```
-📅 Saved sessions for September 2025:
-  1: 2025-09-12 | Start 09:00 | Lunch 45 min | End 17:30 | Expected 18:45 | Surplus -75 min
-  2: 2025-09-13 | Start 08:30 | Lunch 60 min | End 17:45 | Expected 17:30 | Surplus +15 min
-```
-
----
-
-## 🛠 Dependencies
-
-- [rusqlite](https://crates.io/crates/rusqlite) (with `bundled` feature for cross-platform SQLite)
-- [chrono](https://crates.io/crates/chrono) (date & time handling)
-- [clap](https://crates.io/crates/clap) (command-line argument parsing)
-
----
-
-## 📋 Roadmap
-
-- [ ] Export data to CSV/JSON
-- [ ] Daily/weekly/monthly reports
-- [ ] Configurable workday duration
-- [ ] Optional localization (month names, language for output)
-- [ ] Integration with GUI or TUI frontend
-
----
-
-## 📜 License
-
-Licensed under the MIT License.  
+This project is licensed under the MIT License.  
 See [LICENSE](LICENSE) for details.

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,7 +69,7 @@ impl Config {
 
         // Create empty DB file if not exists
         if !db_path.exists() {
-            std::fs::File::create(&db_path)?;
+            fs::File::create(&db_path)?;
         }
 
         println!("✅ Config file: {:?}", Self::config_file());

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,80 @@
+use serde::{Deserialize, Serialize};
+use std::env;
+use std::fs;
+use std::io::{self, Write};
+use std::path::PathBuf;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Config {
+    pub database: String,
+    pub default_position: String,
+}
+
+impl Config {
+    /// Return the standard configuration directory depending on the platform
+    pub fn config_dir() -> PathBuf {
+        if cfg!(target_os = "windows") {
+            let appdata = env::var("APPDATA").unwrap_or_else(|_| ".".to_string());
+            PathBuf::from(appdata).join("rtimelog")
+        } else {
+            let home = env::var("HOME").unwrap_or_else(|_| ".".to_string());
+            PathBuf::from(home).join(".rtimelog")
+        }
+    }
+
+    /// Return the full path of the config file
+    pub fn config_file() -> PathBuf {
+        Self::config_dir().join("rtimelog.conf")
+    }
+
+    /// Return the full path of the SQLite database
+    pub fn database_file() -> PathBuf {
+        Self::config_dir().join("rtimelog.sqlite")
+    }
+
+    /// Load configuration from file, or return defaults if not found
+    pub fn load() -> Self {
+        let path = Self::config_file();
+
+        if path.exists() {
+            let content = fs::read_to_string(&path).expect("❌ Failed to read configuration file");
+            serde_yaml::from_str(&content).expect("❌ Failed to parse configuration file")
+        } else {
+            Config {
+                database: Self::database_file().to_string_lossy().to_string(),
+                default_position: "A".to_string(),
+            }
+        }
+    }
+
+    /// Initialize configuration and database files
+    pub fn init_all(custom_name: Option<String>) -> io::Result<()> {
+        let dir = Self::config_dir();
+        fs::create_dir_all(&dir)?;
+
+        // DB name: user provided or default
+        let db_name = custom_name.unwrap_or_else(|| "rtimelog.sqlite".to_string());
+        let db_path = dir.join(&db_name);
+
+        // Default config
+        let config = Config {
+            database: db_path.to_string_lossy().to_string(),
+            default_position: "A".to_string(),
+        };
+
+        // Write config file
+        let yaml = serde_yaml::to_string(&config).unwrap();
+        let mut file = fs::File::create(Self::config_file())?;
+        file.write_all(yaml.as_bytes())?;
+
+        // Create empty DB file if not exists
+        if !db_path.exists() {
+            std::fs::File::create(&db_path)?;
+        }
+
+        println!("✅ Config file: {:?}", Self::config_file());
+        println!("✅ Database:    {:?}", db_path);
+
+        Ok(())
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,7 +42,7 @@ impl Config {
         } else {
             Config {
                 database: Self::database_file().to_string_lossy().to_string(),
-                default_position: "A".to_string(),
+                default_position: "O".to_string(),
             }
         }
     }
@@ -59,7 +59,7 @@ impl Config {
         // Default config
         let config = Config {
             database: db_path.to_string_lossy().to_string(),
-            default_position: "A".to_string(),
+            default_position: "O".to_string(),
         };
 
         // Write config file

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,26 +1,53 @@
 use rusqlite::{Connection, Result, params};
 
 /// Represents a work session entry
+#[derive(Debug, Clone)]
 pub struct WorkSession {
     pub id: i32,
     pub date: String,
+    pub position: String, // "A" (office) or "R" (remote)
     pub start: String,
     pub lunch: i32,
     pub end: String,
 }
 
-/// Initialize the database (create table if it does not exist)
+/// Initialize the database schema.
+/// Ensures table `work_sessions` exists and adds missing `position` column if required.
 pub fn init_db(conn: &Connection) -> Result<()> {
-    conn.execute(
-        "CREATE TABLE IF NOT EXISTS work_sessions (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            date TEXT NOT NULL,
-            start_time TEXT NOT NULL,
-            lunch_break INTEGER NOT NULL DEFAULT 0,
-            end_time TEXT NOT NULL
-        )",
-        [],
+    conn.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS work_sessions (
+            id           INTEGER PRIMARY KEY AUTOINCREMENT,
+            date         TEXT NOT NULL,          -- YYYY-MM-DD
+            position     TEXT NOT NULL DEFAULT 'A' CHECK (position IN ('A','R')),
+            start_time   TEXT NOT NULL DEFAULT '',
+            lunch_break  INTEGER NOT NULL DEFAULT 0,
+            end_time     TEXT NOT NULL DEFAULT ''
+        );
+        ",
     )?;
+    ensure_position_column(conn)?; // migration for old databases
+    Ok(())
+}
+
+/// Ensure the `position` column exists (for database migrations).
+fn ensure_position_column(conn: &Connection) -> Result<()> {
+    let mut has_col = false;
+    let mut stmt = conn.prepare("PRAGMA table_info(work_sessions)")?;
+    let mut rows = stmt.query([])?;
+    while let Some(row) = rows.next()? {
+        let name: String = row.get(1)?; // column name
+        if name == "position" {
+            has_col = true;
+            break;
+        }
+    }
+    if !has_col {
+        conn.execute(
+            "ALTER TABLE work_sessions ADD COLUMN position TEXT NOT NULL DEFAULT 'A' CHECK (position IN ('A','R'))",
+            []
+        )?;
+    }
     Ok(())
 }
 
@@ -28,28 +55,29 @@ pub fn init_db(conn: &Connection) -> Result<()> {
 pub fn add_session(
     conn: &Connection,
     date: &str,
+    position: &str,
     start: &str,
     lunch: u32,
     end: &str,
 ) -> Result<()> {
     conn.execute(
-        "INSERT INTO work_sessions (date, start_time, lunch_break, end_time)
-         VALUES (?1, ?2, ?3, ?4)",
-        params![date, start, lunch, end],
+        "INSERT INTO work_sessions (date, position, start_time, lunch_break, end_time)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![date, position, start, lunch, end],
     )?;
     Ok(())
 }
 
-/// Retrieve all stored sessions
-/// Retrieve all stored sessions, optionally filtered by month (01-12)
+/// Return all saved work sessions, optionally filtered by year or year-month.
 pub fn list_sessions(conn: &Connection, period: Option<&str>) -> Result<Vec<WorkSession>> {
     let mapper = |row: &rusqlite::Row| {
         Ok(WorkSession {
             id: row.get(0)?,
             date: row.get(1)?,
-            start: row.get(2)?,
-            lunch: row.get(3)?,
-            end: row.get(4)?,
+            position: row.get(2)?,
+            start: row.get(3)?,
+            lunch: row.get(4)?,
+            end: row.get(5)?,
         })
     };
 
@@ -58,29 +86,27 @@ pub fn list_sessions(conn: &Connection, period: Option<&str>) -> Result<Vec<Work
 
     if let Some(p) = period {
         if p.len() == 4 {
-            // Filter only by year
             stmt = conn.prepare(
-                "SELECT id, date, start_time, lunch_break, end_time
+                "SELECT id, date, position, start_time, lunch_break, end_time
                  FROM work_sessions
                  WHERE strftime('%Y', date) = ?1
                  ORDER BY date ASC",
             )?;
             rows = stmt.query_map([p], mapper)?;
         } else if p.len() == 7 {
-            // Filter by year + month
             stmt = conn.prepare(
-                "SELECT id, date, start_time, lunch_break, end_time
+                "SELECT id, date, position, start_time, lunch_break, end_time
                  FROM work_sessions
                  WHERE strftime('%Y-%m', date) = ?1
                  ORDER BY date ASC",
             )?;
             rows = stmt.query_map([p], mapper)?;
         } else {
-            return Err(rusqlite::Error::InvalidQuery); // o un Result custom con messaggio
+            return Err(rusqlite::Error::InvalidQuery);
         }
     } else {
         stmt = conn.prepare(
-            "SELECT id, date, start_time, lunch_break, end_time
+            "SELECT id, date, position, start_time, lunch_break, end_time
              FROM work_sessions
              ORDER BY date ASC",
         )?;
@@ -94,6 +120,23 @@ pub fn list_sessions(conn: &Connection, period: Option<&str>) -> Result<Vec<Work
     Ok(result)
 }
 
+/// Insert or update the position (A=office, R=remote) for a given date.
+pub fn upsert_position(conn: &Connection, date: &str, pos: &str) -> Result<()> {
+    let rows = conn.execute(
+        "UPDATE work_sessions SET position = ?1 WHERE date = ?2",
+        (pos, date),
+    )?;
+    if rows == 0 {
+        conn.execute(
+            "INSERT INTO work_sessions (date, position, start_time, lunch_break, end_time)
+             VALUES (?1, ?2, '', 0, '')",
+            (date, pos),
+        )?;
+    }
+    Ok(())
+}
+
+/// Insert or update the start time (HH:MM) for a given date.
 pub fn upsert_start(conn: &Connection, date: &str, start: &str) -> Result<()> {
     let rows = conn.execute(
         "UPDATE work_sessions SET start_time = ?1 WHERE date = ?2",
@@ -101,14 +144,15 @@ pub fn upsert_start(conn: &Connection, date: &str, start: &str) -> Result<()> {
     )?;
     if rows == 0 {
         conn.execute(
-            "INSERT INTO work_sessions (date, start_time, lunch_break, end_time)
-             VALUES (?1, ?2, 0, '')",
+            "INSERT INTO work_sessions (date, position, start_time, lunch_break, end_time)
+             VALUES (?1, 'A', ?2, 0, '')",
             (date, start),
         )?;
     }
     Ok(())
 }
 
+/// Insert or update the lunch break (minutes) for a given date.
 pub fn upsert_lunch(conn: &Connection, date: &str, lunch: i32) -> Result<()> {
     let rows = conn.execute(
         "UPDATE work_sessions SET lunch_break = ?1 WHERE date = ?2",
@@ -116,14 +160,15 @@ pub fn upsert_lunch(conn: &Connection, date: &str, lunch: i32) -> Result<()> {
     )?;
     if rows == 0 {
         conn.execute(
-            "INSERT INTO work_sessions (date, start_time, lunch_break, end_time)
-             VALUES (?1, '', ?2, '')",
+            "INSERT INTO work_sessions (date, position, start_time, lunch_break, end_time)
+             VALUES (?1, 'A', '', ?2, '')",
             (date, lunch),
         )?;
     }
     Ok(())
 }
 
+/// Insert or update the end time (HH:MM) for a given date.
 pub fn upsert_end(conn: &Connection, date: &str, end: &str) -> Result<()> {
     let rows = conn.execute(
         "UPDATE work_sessions SET end_time = ?1 WHERE date = ?2",
@@ -131,8 +176,8 @@ pub fn upsert_end(conn: &Connection, date: &str, end: &str) -> Result<()> {
     )?;
     if rows == 0 {
         conn.execute(
-            "INSERT INTO work_sessions (date, start_time, lunch_break, end_time)
-             VALUES (?1, '', 0, ?2)",
+            "INSERT INTO work_sessions (date, position, start_time, lunch_break, end_time)
+             VALUES (?1, 'A', '', 0, ?2)",
             (date, end),
         )?;
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -19,7 +19,7 @@ pub fn init_db(conn: &Connection) -> Result<()> {
         CREATE TABLE IF NOT EXISTS work_sessions (
             id           INTEGER PRIMARY KEY AUTOINCREMENT,
             date         TEXT NOT NULL,          -- YYYY-MM-DD
-            position     TEXT NOT NULL DEFAULT 'A' CHECK (position IN ('A','R')),
+            position     TEXT NOT NULL DEFAULT 'O' CHECK (position IN ('O','R')),
             start_time   TEXT NOT NULL DEFAULT '',
             lunch_break  INTEGER NOT NULL DEFAULT 0,
             end_time     TEXT NOT NULL DEFAULT ''
@@ -44,7 +44,7 @@ fn ensure_position_column(conn: &Connection) -> Result<()> {
     }
     if !has_col {
         conn.execute(
-            "ALTER TABLE work_sessions ADD COLUMN position TEXT NOT NULL DEFAULT 'A' CHECK (position IN ('A','R'))",
+            "ALTER TABLE work_sessions ADD COLUMN position TEXT NOT NULL DEFAULT 'O' CHECK (position IN ('O','R'))",
             []
         )?;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod config;
 pub mod db;
 pub mod logic;

--- a/src/logic.rs
+++ b/src/logic.rs
@@ -47,3 +47,21 @@ pub fn calculate_surplus(start: &str, lunch: i32, end: &str) -> Duration {
 
     actual - expected
 }
+
+/// Check if the work interval crosses the lunch window (12:30–14:30).
+pub fn crosses_lunch_window(start: &str, end: &str) -> bool {
+    let start_time = NaiveTime::parse_from_str(start, "%H:%M");
+    let end_time = NaiveTime::parse_from_str(end, "%H:%M");
+
+    if start_time.is_err() || end_time.is_err() {
+        return false;
+    }
+
+    let start_time = start_time.unwrap();
+    let end_time = end_time.unwrap();
+
+    let lunch_window_start = NaiveTime::parse_from_str("12:30", "%H:%M").unwrap();
+    let lunch_window_end = NaiveTime::parse_from_str("14:30", "%H:%M").unwrap();
+
+    start_time < lunch_window_end && end_time > lunch_window_start
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,32 +18,40 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Initialize the database
-    Init,
-    /// Add a new work session
+    /// Add or update a work session
     Add {
-        /// Date of the session (YYYY-MM-DD)
-        #[arg(index = 1)]
+        /// The date (YYYY-MM-DD)
         date: String,
 
         /// Start time (HH:MM)
-        #[arg(index = 2)]
-        start: String,
+        start_pos: Option<String>,
 
         /// Lunch break in minutes (30–90)
-        #[arg(index = 3)]
-        lunch: u32,
+        lunch_pos: Option<i32>,
 
-        /// End time (HH:MM)
-        #[arg(index = 4)]
-        end: String,
+        /// End time (HH:MM) - optional positional arg
+        end_pos: Option<String>,
+
+        /// Start time (HH:MM) via option
+        #[arg(long = "in")]
+        start: Option<String>,
+
+        /// Lunch break in minutes via option
+        #[arg(long = "lunch")]
+        lunch: Option<i32>,
+
+        /// End time (HH:MM) via option
+        #[arg(long = "out")]
+        end: Option<String>,
     },
-    /// List all work sessions
+
+    /// List sessions
     List {
-        /// Filter by year (e.g., 2025) or year-month (e.g., 2025-09)
         #[arg(long, short)]
         period: Option<String>,
     },
+
+    Init,
 }
 
 fn main() -> rusqlite::Result<()> {
@@ -60,17 +68,62 @@ fn main() -> rusqlite::Result<()> {
 
         Commands::Add {
             date,
+            start_pos,
+            lunch_pos,
+            end_pos,
             start,
             lunch,
             end,
         } => {
-            // Basic input validation
-            NaiveDate::parse_from_str(&date, "%Y-%m-%d").expect("Invalid date format (YYYY-MM-DD)");
-            NaiveTime::parse_from_str(&start, "%H:%M").expect("Invalid start time format (HH:MM)");
-            NaiveTime::parse_from_str(&end, "%H:%M").expect("Invalid end time format (HH:MM)");
+            let conn = Connection::open("worktime.db")?;
 
-            db::add_session(&conn, &date, &start, lunch, &end)?;
-            println!("💾 Work session saved!");
+            // ✅ Data
+            if NaiveDate::parse_from_str(&date, "%Y-%m-%d").is_err() {
+                eprintln!("❌ Invalid date format: {} (expected YYYY-MM-DD)", date);
+                return Ok(());
+            }
+
+            // Unifica posizionali e opzioni
+            let start = start.or(start_pos);
+            let lunch = lunch.or(lunch_pos);
+            let end = end.or(end_pos);
+
+            // ⏰ Start
+            if let Some(s) = start.as_ref() {
+                if NaiveTime::parse_from_str(s, "%H:%M").is_err() {
+                    eprintln!("❌ Invalid start time: {} (expected HH:MM)", s);
+                    return Ok(());
+                }
+                db::upsert_start(&conn, &date, s)?;
+                println!("✅ Start time {} registered for {}", s, date);
+            }
+
+            // 🍽 Lunch
+            if let Some(l) = lunch {
+                if !(30..=90).contains(&l) {
+                    eprintln!("❌ Invalid lunch break: {} (must be 30–90 minutes)", l);
+                    return Ok(());
+                }
+                db::upsert_lunch(&conn, &date, l)?;
+                println!("✅ Lunch {} min registered for {}", l, date);
+            }
+
+            // 🏁 End
+            if let Some(e) = end.as_ref() {
+                if NaiveTime::parse_from_str(e, "%H:%M").is_err() {
+                    eprintln!("❌ Invalid end time: {} (expected HH:MM)", e);
+                    return Ok(());
+                }
+                db::upsert_end(&conn, &date, e)?;
+                println!("✅ End time {} registered for {}", e, date);
+            }
+
+            // 🚨 Nessun parametro
+            if start.is_none() && lunch.is_none() && end.is_none() {
+                eprintln!("⚠️ Please provide at least one of: start, lunch, end");
+            }
+
+            return Ok(());
         }
 
         Commands::List { period } => {
@@ -91,36 +144,88 @@ fn main() -> rusqlite::Result<()> {
             }
 
             for s in sessions {
-                let expected = logic::calculate_expected_exit(&s.start, s.lunch);
-                let surplus = logic::calculate_surplus(&s.start, s.lunch, &s.end);
-                let surplus_minutes = surplus.num_minutes();
+                let has_start = !s.start.trim().is_empty();
+                let has_end = !s.end.trim().is_empty();
 
-                let color_code = if surplus_minutes < 0 {
-                    "\x1b[31m"
-                } else if surplus_minutes > 0 {
-                    "\x1b[32m"
+                if has_start && has_end {
+                    let start_time = NaiveTime::parse_from_str(&s.start, "%H:%M").unwrap();
+                    let end_time = NaiveTime::parse_from_str(&s.end, "%H:%M").unwrap();
+
+                    let crosses_lunch = logic::crosses_lunch_window(&s.start, &s.end);
+
+                    // pausa da usare nel calcolo
+                    let effective_lunch = if crosses_lunch {
+                        if s.lunch > 0 {
+                            s.lunch
+                        } else {
+                            30 // pausa minima automatica
+                        }
+                    } else {
+                        0
+                    };
+
+                    if crosses_lunch && effective_lunch > 0 {
+                        // ✅ Caso completo con pausa (inserita o automatica)
+                        let expected = logic::calculate_expected_exit(&s.start, effective_lunch);
+                        let surplus = logic::calculate_surplus(&s.start, effective_lunch, &s.end);
+                        let surplus_minutes = surplus.num_minutes();
+
+                        let color_code = if surplus_minutes < 0 {
+                            "\x1b[31m"
+                        } else if surplus_minutes > 0 {
+                            "\x1b[32m"
+                        } else {
+                            "\x1b[0m"
+                        };
+
+                        let formatted_surplus = if surplus_minutes == 0 {
+                            "0".to_string()
+                        } else {
+                            format!("{:+}", surplus_minutes)
+                        };
+
+                        println!(
+                            "{:>3}: {} | Start {} | Lunch {:02} min | End {} | Expected {} | Surplus {}{:>3} min\x1b[0m",
+                            s.id,
+                            s.date,
+                            s.start,
+                            effective_lunch,
+                            s.end,
+                            expected.format("%H:%M"),
+                            color_code,
+                            formatted_surplus
+                        );
+                    } else {
+                        // ✅ Caso senza pausa (lavoro interamente fuori dalla finestra)
+                        let duration = end_time - start_time;
+                        println!(
+                            "{:>3}: {} | Start {} | \x1b[90mLunch   -\x1b[0m    | End {} | \x1b[36mWorked {:>2} h {:02} min\x1b[0m",
+                            s.id,
+                            s.date,
+                            s.start,
+                            s.end,
+                            duration.num_hours(),
+                            duration.num_minutes() % 60
+                        );
+                    }
                 } else {
-                    "\x1b[0m"
-                };
-
-                let formatted_surplus = if surplus_minutes == 0 {
-                    "0".to_string()
-                } else {
-                    format!("{:+}", surplus_minutes)
-                };
-
-                println!(
-                    "{:>3}: {} | Start {} | Lunch {:02} min | End {} | Expected {} | Surplus {}{:>4} min\x1b[0m",
-                    s.id,
-                    s.date,
-                    s.start,
-                    s.lunch,
-                    s.end,
-                    expected.format("%H:%M"),
-                    color_code,
-                    formatted_surplus
-                );
+                    // ⚠️ informazioni incomplete
+                    println!(
+                        "{:>3}: {} | Start {} | Lunch {} | End {}",
+                        s.id,
+                        s.date,
+                        if has_start { &s.start } else { "-" },
+                        if s.lunch > 0 {
+                            format!("{} min", s.lunch)
+                        } else {
+                            "-".to_string()
+                        },
+                        if has_end { &s.end } else { "-" }
+                    );
+                }
             }
+
+            return Ok(());
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use rusqlite::Connection;
 /// CLI application to track working hours with SQLite
 #[derive(Parser)]
 #[command(name = "rTimelog")]
-#[command(version = "0.1.2")]
+#[command(version = "0.1.5")]
 #[command(about = "Track working hours and calculate surplus using SQLite", long_about = None)]
 struct Cli {
     #[command(subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,6 +162,11 @@ fn main() -> rusqlite::Result<()> {
             let conn = Connection::open(&config.database)?;
             let sessions = db::list_sessions(&conn, period.as_deref())?;
 
+            if sessions.is_empty() {
+                println!("⚠️  No recorded sessions found");
+                return Ok(());
+            }
+
             if let Some(p) = period {
                 if p.len() == 4 {
                     println!("📅 Saved sessions for year {}:", p);

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,7 +195,6 @@ fn main() -> rusqlite::Result<()> {
         }
 
         Commands::List { period } => {
-            println!("List: db used = {}", db_path);
             let conn = Connection::open(&db_path)?;
             let sessions = db::list_sessions(&conn, period.as_deref())?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,7 +145,7 @@ fn main() -> rusqlite::Result<()> {
             // ✅ Handle position
             if let Some(p) = pos.as_ref() {
                 let p = p.trim().to_uppercase();
-                if p != "A" && p != "R" {
+                if p != "O" && p != "R" {
                     eprintln!("❌ Invalid position: {} (use A=office or R=remote)", p);
                     return Ok(());
                 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,89 +1,328 @@
 use assert_cmd::Command;
+use predicates::prelude::PredicateBooleanExt;
 use predicates::str::contains;
-use r_timelog::db;
-use rusqlite::Connection;
+use std::path::PathBuf;
+
+/// Create a unique test DB path inside the system temp dir
+fn setup_test_db(name: &str) -> String {
+    let mut path = PathBuf::new();
+    if cfg!(target_os = "windows") {
+        path.push("C:\\Windows\\Temp\\");
+    } else {
+        path.push("/tmp/");
+    }
+    path.push(format!("{}_rtimelog.sqlite", name));
+    let db_path = path.to_string_lossy().to_string();
+    std::fs::remove_file(&db_path).ok(); // reset if exists
+    db_path
+}
 
 #[test]
 fn test_list_sessions_all() {
-    let conn = Connection::open_in_memory().unwrap();
-    db::init_db(&conn).unwrap();
+    let db_path = setup_test_db("all");
+    println!("test_list_sessions_all() Using test DB: {}", db_path);
 
-    db::add_session(&conn, "2025-08-31", "A", "09:00", 30, "17:00").unwrap();
-    db::add_session(&conn, "2025-09-15", "A", "09:00", 30, "17:00").unwrap();
-    db::add_session(&conn, "2024-09-10", "A", "09:00", 30, "17:00").unwrap();
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "init"])
+        .assert()
+        .success();
 
-    let sessions = db::list_sessions(&conn, None).unwrap();
-    assert_eq!(sessions.len(), 3); // tutti
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "add",
+            "2025-08-31",
+            "A",
+            "09:00",
+            "30",
+            "17:00",
+        ])
+        .assert()
+        .success();
+
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "add",
+            "2025-09-15",
+            "A",
+            "09:00",
+            "30",
+            "17:00",
+        ])
+        .assert()
+        .success();
+
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "add",
+            "2024-09-10",
+            "A",
+            "09:00",
+            "30",
+            "17:00",
+        ])
+        .assert()
+        .success();
+
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "list"])
+        .assert()
+        .success()
+        .stdout(contains("2025-08-31"))
+        .stdout(contains("2025-09-15"))
+        .stdout(contains("2024-09-10"));
 }
 
 #[test]
 fn test_list_sessions_filter_year() {
-    let conn = Connection::open_in_memory().unwrap();
-    db::init_db(&conn).unwrap();
+    let db_path = setup_test_db("year");
+    println!(
+        "test_list_sessions_filter_year() Using test DB: {}",
+        db_path
+    );
 
-    db::add_session(&conn, "2025-01-10", "A", "09:00", 30, "17:00").unwrap();
-    db::add_session(&conn, "2025-05-20", "A", "09:00", 30, "17:00").unwrap();
-    db::add_session(&conn, "2024-12-31", "A", "09:00", 30, "17:00").unwrap();
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "init"])
+        .assert()
+        .success();
 
-    let sessions_2025 = db::list_sessions(&conn, Some("2025")).unwrap();
-    assert_eq!(sessions_2025.len(), 2);
-    for s in sessions_2025 {
-        assert!(s.date.starts_with("2025"));
-    }
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "add",
+            "2025-01-10",
+            "A",
+            "09:00",
+            "30",
+            "17:00",
+        ])
+        .assert()
+        .success();
+
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "add",
+            "2025-05-20",
+            "A",
+            "09:00",
+            "30",
+            "17:00",
+        ])
+        .assert()
+        .success();
+
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "add",
+            "2024-12-31",
+            "A",
+            "09:00",
+            "30",
+            "17:00",
+        ])
+        .assert()
+        .success();
+
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "list", "--period", "2025"])
+        .assert()
+        .success()
+        .stdout(contains("2025-01-10"))
+        .stdout(contains("2025-05-20"))
+        .stdout(contains("📅 Saved sessions for year 2025:"))
+        .stdout(
+            predicates::str::is_match("2024-12-31")
+                .expect("Invalid regex")
+                .not(),
+        );
 }
 
 #[test]
 fn test_list_sessions_filter_year_month() {
-    let conn = Connection::open_in_memory().unwrap();
-    db::init_db(&conn).unwrap();
+    let db_path = setup_test_db("year_month");
+    println!(
+        "test_list_sessions_filter_year_month() Using test DB: {}",
+        db_path
+    );
 
-    db::add_session(&conn, "2025-09-01", "A", "09:00", 30, "17:00").unwrap();
-    db::add_session(&conn, "2025-09-15", "A", "09:00", 30, "17:00").unwrap();
-    db::add_session(&conn, "2025-10-01", "A", "09:00", 30, "17:00").unwrap();
-    db::add_session(&conn, "2024-09-01", "A", "09:00", 30, "17:00").unwrap();
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "init"])
+        .assert()
+        .success();
 
-    let sessions_sep_2025 = db::list_sessions(&conn, Some("2025-09")).unwrap();
-    assert_eq!(sessions_sep_2025.len(), 2);
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "add",
+            "2025-09-01",
+            "A",
+            "09:00",
+            "30",
+            "17:00",
+        ])
+        .assert()
+        .success();
 
-    for s in sessions_sep_2025 {
-        assert!(s.date.starts_with("2025-09"));
-    }
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "add",
+            "2025-09-15",
+            "A",
+            "09:00",
+            "30",
+            "17:00",
+        ])
+        .assert()
+        .success();
+
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "add",
+            "2025-10-01",
+            "A",
+            "09:00",
+            "30",
+            "17:00",
+        ])
+        .assert()
+        .success();
+
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "add",
+            "2024-09-01",
+            "A",
+            "09:00",
+            "30",
+            "17:00",
+        ])
+        .assert()
+        .success();
+
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "list", "--period", "2025-09"])
+        .assert()
+        .success()
+        .stdout(contains("2025-09-01"))
+        .stdout(contains("2025-09-15"))
+        .stdout(contains("📅 Saved sessions for September 2025:"))
+        .stdout(
+            predicates::str::is_match("2025-10-01")
+                .expect("Invalid regex")
+                .not(),
+        )
+        .stdout(
+            predicates::str::is_match("2024-09-01")
+                .expect("Invalid regex")
+                .not(),
+        );
 }
 
 #[test]
 fn test_list_sessions_invalid_period() {
-    let conn = Connection::open_in_memory().unwrap();
-    db::init_db(&conn).unwrap();
+    let db_path = setup_test_db("invalid_period");
+    println!(
+        "test_list_sessions_invalid_period() Using test DB: {}",
+        db_path
+    );
 
-    db::add_session(&conn, "2025-09-01", "A", "09:00", 30, "17:00").unwrap();
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "init"])
+        .assert()
+        .success();
 
-    let result = db::list_sessions(&conn, Some("2025-9")); // formato errato
-    assert!(result.is_err());
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "add",
+            "2025-09-01",
+            "A",
+            "09:00",
+            "30",
+            "17:00",
+        ])
+        .assert()
+        .success();
+
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "list", "--period", "2025-9"])
+        .assert()
+        .failure()
+        .stderr(contains("InvalidQuery"));
 }
 
 #[test]
 fn test_add_and_list_with_company_position() {
-    // Clean DB
-    std::fs::remove_file("worktime.sqlite").ok();
+    let db_path = setup_test_db("with_company_position");
+    println!(
+        "test_add_and_list_with_company_position() Using test DB: {}",
+        db_path
+    );
 
     // Init DB
     Command::cargo_bin("rtimelog")
         .unwrap()
-        .arg("init")
+        .args(["--db", &db_path, "init"])
         .assert()
         .success();
 
     // Add a session in company mode (A), crossing lunch window but without specifying lunch
     Command::cargo_bin("rtimelog")
         .unwrap()
-        .args(["add", "2025-09-14", "A", "09:00", "0", "17:00"])
+        .args([
+            "--db",
+            &db_path,
+            "add",
+            "2025-09-14",
+            "A",
+            "09:00",
+            "0",
+            "17:00",
+        ])
         .assert()
         .success();
 
     // List should show Pos A and Lunch 30 min (auto-applied)
     Command::cargo_bin("rtimelog")
         .unwrap()
-        .args(["list"])
+        .args(["--db", &db_path, "list"])
         .assert()
         .success()
         .stdout(contains("Position A"))
@@ -94,58 +333,71 @@ fn test_add_and_list_with_company_position() {
 
 #[test]
 fn test_add_and_list_with_remote_position_lunch_zero() {
-    // Clean DB
-    std::fs::remove_file("worktime.sqlite").ok();
+    let db_path = setup_test_db("with_remote_position_lunch_zero");
+    println!(
+        "test_add_and_list_with_remote_position_lunch_zero() Using test DB: {}",
+        db_path
+    );
 
     // Init DB
     Command::cargo_bin("rtimelog")
         .unwrap()
-        .arg("init")
+        .args(["--db", &db_path, "init"])
         .assert()
         .success();
 
     // Add a session in remote mode (R), crossing lunch window, no lunch specified
     Command::cargo_bin("rtimelog")
         .unwrap()
-        .args(["add", "2025-09-15", "R", "09:00", "0", "17:00"])
+        .args([
+            "--db",
+            &db_path,
+            "add",
+            "2025-09-15",
+            "R",
+            "09:00",
+            "0",
+            "17:00",
+        ])
         .assert()
         .success();
 
     // List should show Pos R and Lunch 0 min (allowed)
     Command::cargo_bin("rtimelog")
         .unwrap()
-        .args(["list"])
+        .args(["--db", &db_path, "list"])
         .assert()
         .success()
         .stdout(contains("Position R"))
-        .stdout(contains("Lunch   -"))
-        .stdout(contains("Expected"))
-        .stdout(contains("Surplus"));
+        .stdout(contains("Lunch   -"));
 }
 
 #[test]
 fn test_add_and_list_incomplete_session() {
-    // Clean DB
-    std::fs::remove_file("worktime.sqlite").ok();
+    let db_path = setup_test_db("incomplete_session");
+    println!(
+        "test_add_and_list_incomplete_session() Using test DB: {}",
+        db_path
+    );
 
     // Init DB
     Command::cargo_bin("rtimelog")
         .unwrap()
-        .arg("init")
+        .args(["--db", &db_path, "init"])
         .assert()
         .success();
 
     // Add only start time (no end)
     Command::cargo_bin("rtimelog")
         .unwrap()
-        .args(["add", "2025-09-16", "A", "09:00"])
+        .args(["--db", &db_path, "add", "2025-09-16", "A", "09:00"])
         .assert()
         .success();
 
     // List should show Pos A and Start 09:00 but End "-"
     Command::cargo_bin("rtimelog")
         .unwrap()
-        .args(["list"])
+        .args(["--db", &db_path, "list"])
         .assert()
         .success()
         .stdout(contains("Position A"))

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -313,7 +313,7 @@ fn test_add_and_list_with_company_position() {
             "2025-09-14",
             "O",
             "09:00",
-            "0",
+            "30",
             "17:00",
         ])
         .assert()

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,3 +1,5 @@
+use assert_cmd::Command;
+use predicates::str::contains;
 use r_timelog::db;
 use rusqlite::Connection;
 
@@ -6,9 +8,9 @@ fn test_list_sessions_all() {
     let conn = Connection::open_in_memory().unwrap();
     db::init_db(&conn).unwrap();
 
-    db::add_session(&conn, "2025-08-31", "09:00", 30, "17:00").unwrap();
-    db::add_session(&conn, "2025-09-15", "09:00", 30, "17:00").unwrap();
-    db::add_session(&conn, "2024-09-10", "09:00", 30, "17:00").unwrap();
+    db::add_session(&conn, "2025-08-31", "A", "09:00", 30, "17:00").unwrap();
+    db::add_session(&conn, "2025-09-15", "A", "09:00", 30, "17:00").unwrap();
+    db::add_session(&conn, "2024-09-10", "A", "09:00", 30, "17:00").unwrap();
 
     let sessions = db::list_sessions(&conn, None).unwrap();
     assert_eq!(sessions.len(), 3); // tutti
@@ -19,9 +21,9 @@ fn test_list_sessions_filter_year() {
     let conn = Connection::open_in_memory().unwrap();
     db::init_db(&conn).unwrap();
 
-    db::add_session(&conn, "2025-01-10", "09:00", 30, "17:00").unwrap();
-    db::add_session(&conn, "2025-05-20", "09:00", 30, "17:00").unwrap();
-    db::add_session(&conn, "2024-12-31", "09:00", 30, "17:00").unwrap();
+    db::add_session(&conn, "2025-01-10", "A", "09:00", 30, "17:00").unwrap();
+    db::add_session(&conn, "2025-05-20", "A", "09:00", 30, "17:00").unwrap();
+    db::add_session(&conn, "2024-12-31", "A", "09:00", 30, "17:00").unwrap();
 
     let sessions_2025 = db::list_sessions(&conn, Some("2025")).unwrap();
     assert_eq!(sessions_2025.len(), 2);
@@ -35,10 +37,10 @@ fn test_list_sessions_filter_year_month() {
     let conn = Connection::open_in_memory().unwrap();
     db::init_db(&conn).unwrap();
 
-    db::add_session(&conn, "2025-09-01", "09:00", 30, "17:00").unwrap();
-    db::add_session(&conn, "2025-09-15", "09:00", 30, "17:00").unwrap();
-    db::add_session(&conn, "2025-10-01", "09:00", 30, "17:00").unwrap();
-    db::add_session(&conn, "2024-09-01", "09:00", 30, "17:00").unwrap();
+    db::add_session(&conn, "2025-09-01", "A", "09:00", 30, "17:00").unwrap();
+    db::add_session(&conn, "2025-09-15", "A", "09:00", 30, "17:00").unwrap();
+    db::add_session(&conn, "2025-10-01", "A", "09:00", 30, "17:00").unwrap();
+    db::add_session(&conn, "2024-09-01", "A", "09:00", 30, "17:00").unwrap();
 
     let sessions_sep_2025 = db::list_sessions(&conn, Some("2025-09")).unwrap();
     assert_eq!(sessions_sep_2025.len(), 2);
@@ -53,8 +55,100 @@ fn test_list_sessions_invalid_period() {
     let conn = Connection::open_in_memory().unwrap();
     db::init_db(&conn).unwrap();
 
-    db::add_session(&conn, "2025-09-01", "09:00", 30, "17:00").unwrap();
+    db::add_session(&conn, "2025-09-01", "A", "09:00", 30, "17:00").unwrap();
 
     let result = db::list_sessions(&conn, Some("2025-9")); // formato errato
     assert!(result.is_err());
+}
+
+#[test]
+fn test_add_and_list_with_company_position() {
+    // Clean DB
+    std::fs::remove_file("worktime.sqlite").ok();
+
+    // Init DB
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .arg("init")
+        .assert()
+        .success();
+
+    // Add a session in company mode (A), crossing lunch window but without specifying lunch
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["add", "2025-09-14", "A", "09:00", "0", "17:00"])
+        .assert()
+        .success();
+
+    // List should show Pos A and Lunch 30 min (auto-applied)
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["list"])
+        .assert()
+        .success()
+        .stdout(contains("Position A"))
+        .stdout(contains("Lunch 30 min"))
+        .stdout(contains("Expected"))
+        .stdout(contains("Surplus"));
+}
+
+#[test]
+fn test_add_and_list_with_remote_position_lunch_zero() {
+    // Clean DB
+    std::fs::remove_file("worktime.sqlite").ok();
+
+    // Init DB
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .arg("init")
+        .assert()
+        .success();
+
+    // Add a session in remote mode (R), crossing lunch window, no lunch specified
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["add", "2025-09-15", "R", "09:00", "0", "17:00"])
+        .assert()
+        .success();
+
+    // List should show Pos R and Lunch 0 min (allowed)
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["list"])
+        .assert()
+        .success()
+        .stdout(contains("Position R"))
+        .stdout(contains("Lunch   -"))
+        .stdout(contains("Expected"))
+        .stdout(contains("Surplus"));
+}
+
+#[test]
+fn test_add_and_list_incomplete_session() {
+    // Clean DB
+    std::fs::remove_file("worktime.sqlite").ok();
+
+    // Init DB
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .arg("init")
+        .assert()
+        .success();
+
+    // Add only start time (no end)
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["add", "2025-09-16", "A", "09:00"])
+        .assert()
+        .success();
+
+    // List should show Pos A and Start 09:00 but End "-"
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["list"])
+        .assert()
+        .success()
+        .stdout(contains("Position A"))
+        .stdout(contains("Start 09:00"))
+        .stdout(contains("End -"));
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -35,7 +35,7 @@ fn test_list_sessions_all() {
             &db_path,
             "add",
             "2025-08-31",
-            "A",
+            "O",
             "09:00",
             "30",
             "17:00",
@@ -50,7 +50,7 @@ fn test_list_sessions_all() {
             &db_path,
             "add",
             "2025-09-15",
-            "A",
+            "O",
             "09:00",
             "30",
             "17:00",
@@ -65,7 +65,7 @@ fn test_list_sessions_all() {
             &db_path,
             "add",
             "2024-09-10",
-            "A",
+            "O",
             "09:00",
             "30",
             "17:00",
@@ -104,7 +104,7 @@ fn test_list_sessions_filter_year() {
             &db_path,
             "add",
             "2025-01-10",
-            "A",
+            "O",
             "09:00",
             "30",
             "17:00",
@@ -119,7 +119,7 @@ fn test_list_sessions_filter_year() {
             &db_path,
             "add",
             "2025-05-20",
-            "A",
+            "O",
             "09:00",
             "30",
             "17:00",
@@ -134,7 +134,7 @@ fn test_list_sessions_filter_year() {
             &db_path,
             "add",
             "2024-12-31",
-            "A",
+            "O",
             "09:00",
             "30",
             "17:00",
@@ -178,7 +178,7 @@ fn test_list_sessions_filter_year_month() {
             &db_path,
             "add",
             "2025-09-01",
-            "A",
+            "O",
             "09:00",
             "30",
             "17:00",
@@ -193,7 +193,7 @@ fn test_list_sessions_filter_year_month() {
             &db_path,
             "add",
             "2025-09-15",
-            "A",
+            "O",
             "09:00",
             "30",
             "17:00",
@@ -208,7 +208,7 @@ fn test_list_sessions_filter_year_month() {
             &db_path,
             "add",
             "2025-10-01",
-            "A",
+            "O",
             "09:00",
             "30",
             "17:00",
@@ -223,7 +223,7 @@ fn test_list_sessions_filter_year_month() {
             &db_path,
             "add",
             "2024-09-01",
-            "A",
+            "O",
             "09:00",
             "30",
             "17:00",
@@ -272,7 +272,7 @@ fn test_list_sessions_invalid_period() {
             &db_path,
             "add",
             "2025-09-01",
-            "A",
+            "O",
             "09:00",
             "30",
             "17:00",
@@ -311,7 +311,7 @@ fn test_add_and_list_with_company_position() {
             &db_path,
             "add",
             "2025-09-14",
-            "A",
+            "O",
             "09:00",
             "0",
             "17:00",
@@ -325,7 +325,7 @@ fn test_add_and_list_with_company_position() {
         .args(["--db", &db_path, "list"])
         .assert()
         .success()
-        .stdout(contains("Position A"))
+        .stdout(contains("Position O"))
         .stdout(contains("Lunch 30 min"))
         .stdout(contains("Expected"))
         .stdout(contains("Surplus"));
@@ -390,7 +390,7 @@ fn test_add_and_list_incomplete_session() {
     // Add only start time (no end)
     Command::cargo_bin("rtimelog")
         .unwrap()
-        .args(["--db", &db_path, "add", "2025-09-16", "A", "09:00"])
+        .args(["--db", &db_path, "add", "2025-09-16", "O", "09:00"])
         .assert()
         .success();
 
@@ -400,7 +400,7 @@ fn test_add_and_list_incomplete_session() {
         .args(["--db", &db_path, "list"])
         .assert()
         .success()
-        .stdout(contains("Position A"))
+        .stdout(contains("Position O"))
         .stdout(contains("Start 09:00"))
         .stdout(contains("End -"));
 }


### PR DESCRIPTION
## [0.2.0] - 2025-09-xx
### Added
- Creation of a configuration file in the user home (depending on platform) with:
    - DB filename
    - Default working position (`A`)
- New column `position` in SQLite DB to identify the working position of the day:
    - `O` = Office
    - `R` = Remote
- New options for `add` command:
    - `--pos` add the working position of the day, O = Office, R = Remote
    - `--in` add the start hour of work
    - `--lunch` add the duration of lunch
    - `--out` add the end hour of work
- Added global option `--db` to specify:
    - a DB name (created under rTimelog config directory)
    - or an absolute DB path
- Added a message when the DB is empty (`⚠️ No recorded sessions found`)

### Changed
- Reorganized the output of the `list` command
- Updated integration tests for new DB column `position`
- Updated the logic for opening the connection to the DB file
- Updated integration tests to use `--db` option

### Notes
- Previous intermediate changes introduced `--name` and config file handling,
  but they have been replaced by the new global `--db` approach for consistency.
