### PR TITLE
V0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 # Changelog
 
+# Changelog
+
+## [0.2.1] - 2025-09-xx
+### Added
+- Support in `init` command for initializing a new database in:
+  - an absolute path
+  - directories containing spaces in their names
+
+### Changed
+- Updated `list` command: now shows the **expected end time** even when only the start time is provided for a given date
+- Updated integration tests for the new version v0.2.1
+
+---
+
 ## [0.2.0] - 2025-09-14
 ### Added
 - Creation of a configuration file in the user home (depending on platform) with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 # Changelog
 
-## [0.2.1] - 2025-09-xx
+## [0.2.1] - 2025-09-15
 ### Added
 - Support in `init` command for initializing a new database in:
   - an absolute path

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "r_timelog"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r_timelog"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 authors = ["Umpire274 <umpire274@gmail.com>"]
 description = "A simple cross-platform CLI tool to track working hours, lunch breaks, and calculate surplus time"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The tool calculates the expected exit time and the surplus of worked minutes.
   - `--in` start time (HH:MM)
   - `--lunch` lunch duration in minutes (0–90)
   - `--out` end time (HH:MM)
-- Automatic normalization of lunch time if working from the Office:
+- Automatic normalization of lunchtime if working from the Office:
   - Minimum 30 minutes
   - Maximum 90 minutes
   - If less than 30 minutes are taken, the missing time is added to the expected exit time
@@ -49,6 +49,9 @@ rtimelog --db custom.sqlite init
 
 # Initialize with absolute path
 rtimelog --db /tmp/test.sqlite init
+
+# Initialize with an absolute path containing spaces (Windows version)
+rtimelog --db "G:\My Drive\Work\ACMEinc\timetable\rtimelog.sqlite" init
 ```
 
 ### Add sessions

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,10 +53,17 @@ impl Config {
         fs::create_dir_all(&dir)?;
 
         // DB name: user provided or default
-        let db_name = custom_name.unwrap_or_else(|| "rtimelog.sqlite".to_string());
-        let db_path = dir.join(&db_name);
+        let db_path = if let Some(name) = custom_name {
+            let p = std::path::Path::new(&name);
+            if p.is_absolute() {
+                p.to_path_buf()
+            } else {
+                dir.join(p)
+            }
+        } else {
+            dir.join("rtimelog.sqlite")
+        };
 
-        // Default config
         let config = Config {
             database: db_path.to_string_lossy().to_string(),
             default_position: "O".to_string(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,7 @@ impl Config {
     /// Load configuration from file, or return defaults if not found
     pub fn load() -> Self {
         let path = Self::config_file();
+        println!("Config::load() - Loading config from {:?}", path);
 
         if path.exists() {
             let content = fs::read_to_string(&path).expect("❌ Failed to read configuration file");
@@ -48,7 +49,7 @@ impl Config {
     }
 
     /// Initialize configuration and database files
-    pub fn init_all(custom_name: Option<String>) -> io::Result<()> {
+    pub fn init_all(custom_name: Option<String>, is_test: bool) -> io::Result<()> {
         let dir = Self::config_dir();
         fs::create_dir_all(&dir)?;
 
@@ -70,16 +71,18 @@ impl Config {
         };
 
         // Write config file
-        let yaml = serde_yaml::to_string(&config).unwrap();
-        let mut file = fs::File::create(Self::config_file())?;
-        file.write_all(yaml.as_bytes())?;
+        if !is_test {
+            let yaml = serde_yaml::to_string(&config).unwrap();
+            let mut file = fs::File::create(Self::config_file())?;
+            file.write_all(yaml.as_bytes())?;
+            println!("✅ Config file: {:?}", Self::config_file());
+        }
 
         // Create empty DB file if not exists
         if !db_path.exists() {
             fs::File::create(&db_path)?;
         }
 
-        println!("✅ Config file: {:?}", Self::config_file());
         println!("✅ Database:    {:?}", db_path);
 
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,10 +220,21 @@ fn main() -> rusqlite::Result<()> {
                 let has_start = !s.start.trim().is_empty();
                 let has_end = !s.end.trim().is_empty();
 
-                if has_start && has_end {
+                if has_start && !has_end {
+                    // I have only start hour, then I calculate expected end
+                    let expected = logic::calculate_expected_exit(&s.start, 0);
+                    println!(
+                        "{:>3}: {} | Position {} | Start {} | \x1b[90mLunch   -\x1b[0m    | \x1b[90mEnd   -\x1b[0m   | Expected {} | \x1b[90mSurplus   -\x1b[0m",
+                        s.id,
+                        s.date,
+                        s.position,
+                        s.start,
+                        expected.format("%H:%M"),
+                    );
+                } else if has_start && has_end {
                     let start_time = NaiveTime::parse_from_str(&s.start, "%H:%M").unwrap();
                     let end_time = NaiveTime::parse_from_str(&s.end, "%H:%M").unwrap();
-                    let pos_char = s.position.chars().next().unwrap_or('A');
+                    let pos_char = s.position.chars().next().unwrap_or('O');
                     let crosses_lunch = logic::crosses_lunch_window(&s.start, &s.end);
 
                     // Compute effective lunch

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,35 +85,18 @@ fn main() -> rusqlite::Result<()> {
     match cli.command {
         Commands::Init => {
             if let Some(custom) = &cli.db {
-                let custom_path = std::path::Path::new(custom);
-                if custom_path.is_absolute() {
-                    // percorso assoluto → gestito direttamente
-                    if let Some(parent) = custom_path.parent() {
-                        std::fs::create_dir_all(parent).unwrap();
-                    }
-                    if !custom_path.exists() {
-                        std::fs::File::create(custom_path).unwrap();
-                    }
-                    let conn = Connection::open(custom_path)?;
-                    db::init_db(&conn)?;
-                    println!("✅ Database initialized at {}", custom_path.display());
-                } else {
-                    // solo nome file → lascia a Config::init_all la gestione
-                    Config::init_all(Some(custom.clone())).unwrap();
-                    let config = Config::load();
-                    let conn = Connection::open(&config.database)?;
-                    db::init_db(&conn)?;
-                    println!("✅ Database initialized at {}", config.database);
-                }
+                // Passa sempre la stringa a init_all, sia nome che path assoluto
+                Config::init_all(Some(custom.clone())).unwrap();
             } else {
-                // nessun parametro → default
                 Config::init_all(None).unwrap();
-                let config = Config::load();
-                let conn = Connection::open(&config.database)?;
-                db::init_db(&conn)?;
-                println!("✅ Database initialized at {}", config.database);
             }
 
+            // Ora carichiamo la config salvata
+            let config = Config::load();
+            let conn = Connection::open(&config.database)?;
+            db::init_db(&conn)?;
+
+            println!("✅ Database initialized at {}", config.database);
             Ok(())
         }
 
@@ -262,7 +245,7 @@ fn main() -> rusqlite::Result<()> {
                         };
 
                         println!(
-                            "{:>3}: {} | Position {} | Start {} | Lunch {:02} min | End {} | Expected {} | Surplus {}{:>3} min\x1b[0m",
+                            "{:>3}: {} | Position {} | Start {} | Lunch {:02} min | End {} | Expected {} | Surplus {}{:>4} min\x1b[0m",
                             s.id,
                             s.date,
                             s.position,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -26,7 +26,7 @@ fn test_list_sessions_all() {
 
     Command::cargo_bin("rtimelog")
         .unwrap()
-        .args(["--db", &db_path, "init"])
+        .args(["--db", &db_path, "--test", "init"])
         .assert()
         .success();
 
@@ -96,7 +96,7 @@ fn test_list_sessions_filter_year() {
 
     Command::cargo_bin("rtimelog")
         .unwrap()
-        .args(["--db", &db_path, "init"])
+        .args(["--db", &db_path, "--test", "init"])
         .assert()
         .success();
 
@@ -171,7 +171,7 @@ fn test_list_sessions_filter_year_month() {
 
     Command::cargo_bin("rtimelog")
         .unwrap()
-        .args(["--db", &db_path, "init"])
+        .args(["--db", &db_path, "--test", "init"])
         .assert()
         .success();
 
@@ -266,7 +266,7 @@ fn test_list_sessions_invalid_period() {
 
     Command::cargo_bin("rtimelog")
         .unwrap()
-        .args(["--db", &db_path, "init"])
+        .args(["--db", &db_path, "--test", "init"])
         .assert()
         .success();
 
@@ -305,7 +305,7 @@ fn test_add_and_list_with_company_position() {
     // Init DB
     Command::cargo_bin("rtimelog")
         .unwrap()
-        .args(["--db", &db_path, "init"])
+        .args(["--db", &db_path, "--test", "init"])
         .assert()
         .success();
 
@@ -349,7 +349,7 @@ fn test_add_and_list_with_remote_position_lunch_zero() {
     // Init DB
     Command::cargo_bin("rtimelog")
         .unwrap()
-        .args(["--db", &db_path, "init"])
+        .args(["--db", &db_path, "--test", "init"])
         .assert()
         .success();
 
@@ -391,7 +391,7 @@ fn test_add_and_list_incomplete_session() {
     // Init DB
     Command::cargo_bin("rtimelog")
         .unwrap()
-        .args(["--db", &db_path, "init"])
+        .args(["--db", &db_path, "--test", "init"])
         .assert()
         .success();
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2,13 +2,19 @@ use assert_cmd::Command;
 use predicates::prelude::PredicateBooleanExt;
 use predicates::str::contains;
 use std::env;
+use std::path::PathBuf;
 
 /// Create a unique test DB path inside the system temp dir
 fn setup_test_db(name: &str) -> String {
-    let mut path = env::temp_dir();
+    // Cross-platform: /tmp su Linux/macOS, %TEMP% su Windows
+    let mut path: PathBuf = env::temp_dir();
     path.push(format!("{}_rtimelog.sqlite", name));
+
     let db_path = path.to_string_lossy().to_string();
-    std::fs::remove_file(&db_path).ok(); // reset if exists
+
+    // Rimuove il file se esiste già (reset)
+    std::fs::remove_file(&db_path).ok();
+
     db_path
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -402,5 +402,5 @@ fn test_add_and_list_incomplete_session() {
         .success()
         .stdout(contains("Position O"))
         .stdout(contains("Start 09:00"))
-        .stdout(contains("End -"));
+        .stdout(contains("End   -"));
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -21,6 +21,7 @@ fn setup_test_db(name: &str) -> String {
 #[test]
 fn test_list_sessions_all() {
     let db_path = setup_test_db("all");
+    println!("Temp dir: {:?}", env::temp_dir());
     println!("test_list_sessions_all() Using test DB: {}", db_path);
 
     Command::cargo_bin("rtimelog")
@@ -87,6 +88,7 @@ fn test_list_sessions_all() {
 #[test]
 fn test_list_sessions_filter_year() {
     let db_path = setup_test_db("year");
+    println!("Temp dir: {:?}", env::temp_dir());
     println!(
         "test_list_sessions_filter_year() Using test DB: {}",
         db_path
@@ -161,6 +163,7 @@ fn test_list_sessions_filter_year() {
 #[test]
 fn test_list_sessions_filter_year_month() {
     let db_path = setup_test_db("year_month");
+    println!("Temp dir: {:?}", env::temp_dir());
     println!(
         "test_list_sessions_filter_year_month() Using test DB: {}",
         db_path
@@ -255,6 +258,7 @@ fn test_list_sessions_filter_year_month() {
 #[test]
 fn test_list_sessions_invalid_period() {
     let db_path = setup_test_db("invalid_period");
+    println!("Temp dir: {:?}", env::temp_dir());
     println!(
         "test_list_sessions_invalid_period() Using test DB: {}",
         db_path
@@ -292,6 +296,7 @@ fn test_list_sessions_invalid_period() {
 #[test]
 fn test_add_and_list_with_company_position() {
     let db_path = setup_test_db("with_company_position");
+    println!("Temp dir: {:?}", env::temp_dir());
     println!(
         "test_add_and_list_with_company_position() Using test DB: {}",
         db_path
@@ -335,6 +340,7 @@ fn test_add_and_list_with_company_position() {
 #[test]
 fn test_add_and_list_with_remote_position_lunch_zero() {
     let db_path = setup_test_db("with_remote_position_lunch_zero");
+    println!("Temp dir: {:?}", env::temp_dir());
     println!(
         "test_add_and_list_with_remote_position_lunch_zero() Using test DB: {}",
         db_path
@@ -376,6 +382,7 @@ fn test_add_and_list_with_remote_position_lunch_zero() {
 #[test]
 fn test_add_and_list_incomplete_session() {
     let db_path = setup_test_db("incomplete_session");
+    println!("Temp dir: {:?}", env::temp_dir());
     println!(
         "test_add_and_list_incomplete_session() Using test DB: {}",
         db_path

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,16 +1,11 @@
 use assert_cmd::Command;
 use predicates::prelude::PredicateBooleanExt;
 use predicates::str::contains;
-use std::path::PathBuf;
+use std::env;
 
 /// Create a unique test DB path inside the system temp dir
 fn setup_test_db(name: &str) -> String {
-    let mut path = PathBuf::new();
-    if cfg!(target_os = "windows") {
-        path.push("C:\\Windows\\Temp\\");
-    } else {
-        path.push("/tmp/");
-    }
+    let mut path = env::temp_dir();
     path.push(format!("{}_rtimelog.sqlite", name));
     let db_path = path.to_string_lossy().to_string();
     std::fs::remove_file(&db_path).ok(); // reset if exists


### PR DESCRIPTION
## [0.2.1] - 2025-09-15
### Added
- Support in `init` command for initializing a new database in:
  - an absolute path
  - directories containing spaces in their names

### Changed
- Updated `list` command: now shows the **expected end time** even when only the start time is provided for a given date
- Updated integration tests for the new version v0.2.1
