### PR TITLE
V0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,28 @@
 # Changelog
 
+# [0.3.1] - 2025-09-17
+### Added
+
+- New global option `--pos` in the `list` command to filter sessions by working position:
+    - `O` = Office
+    - `R` = Remote
+    - `H` = Holiday
+- A function `make_separator` and `print_separator` in `utils.rs` to generate aligned separators with custom character,
+  width, and alignment.
+- Unit tests for `make_separator`.
+- Integration test for the new `--pos` option of `list` command.
+- Display of the **total surplus** (sum of daily surpluses) at the end of the `list` output.
+
+### Changed
+
+- Improved the output formatting of the `list` command, including:
+    - aligned `Lunch` time using `HH:MM` or padded `-`
+    - cleaner separator handling with the new utility functions.
+
+---
+
 # [0.3.0] - 2025-09-16
+
 ### Added
 
 - New parameter `working_time` in application configuration file to define the daily working duration.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "r_timelog"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r_timelog"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 authors = ["Umpire274 <umpire274@gmail.com>"]
 description = "A simple cross-platform CLI tool to track working hours, lunch breaks, and calculate surplus time"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The tool calculates the expected exit time and the surplus of worked minutes.
     - Maximum 1h 30m
     - Required only for `Office` position (`O`)
 - View surplus/deficit of worked time compared to expected
+- Display of the **total surplus** (sum of daily surplus/deficit) at the end of the `list` output.
 - Automatic database migration for schema changes
 - Cross-platform configuration file management:
     - Linux/macOS: `$HOME/.rtimelog/rtimelog.conf`
@@ -138,6 +139,14 @@ By year and month:
 
 ```bash
 rtimelog list --period 2025-09
+```
+
+For working position (O, R, H). You can specify the position in either uppercase or lowercase:
+
+```bash
+rtimelog list --pos O
+rtimelog list --pos R
+rtimelog list --pos H
 ```
 
 ---

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -188,6 +188,8 @@ pub fn handle_list(period: Option<String>, db_path: &str) -> rusqlite::Result<()
         println!("📅 Saved sessions:");
     }
 
+    let mut total_surplus = 0;
+
     for s in sessions {
         if s.position == "H" {
             //println!("{:>3}: {} | \x1b[35mHoliday\x1b[0m",s.id,s.date);
@@ -217,11 +219,7 @@ pub fn handle_list(period: Option<String>, db_path: &str) -> rusqlite::Result<()
             let lunch_fmt = format!("{:^5}", lunch_str);
 
             let end_color = if s.end != "" { "\x1b[0m" } else { "\x1b[90m" };
-            let end_str = if s.end != "" {
-                s.end
-            } else {
-                "-".to_string()
-            };
+            let end_str = if s.end != "" { s.end } else { "-".to_string() };
             // Forza la larghezza a 5 caratteri, allineato a destra
             let end_fmt = format!("{:^5}", end_str);
 
@@ -256,6 +254,7 @@ pub fn handle_list(period: Option<String>, db_path: &str) -> rusqlite::Result<()
                 let surplus =
                     logic::calculate_surplus(&s.start, effective_lunch, &s.end, work_minutes);
                 let surplus_minutes = surplus.num_minutes();
+                total_surplus += surplus_minutes;
 
                 let color_code = if surplus_minutes < 0 {
                     "\x1b[31m"
@@ -333,6 +332,28 @@ pub fn handle_list(period: Option<String>, db_path: &str) -> rusqlite::Result<()
                 if has_end { &s.end } else { "-" }
             );
         }
+    }
+
+    println!("\n{:>104}", "=".repeat(25));
+
+    if total_surplus != 0 {
+        let color_code = if total_surplus < 0 {
+            "\x1b[31m" // rosso
+        } else {
+            "\x1b[32m" // verde
+        };
+
+        let formatted_total = format!("{:+}", total_surplus);
+
+        println!(
+            "{:>113}",
+            format!(
+                "Σ Total surplus: {}{:>4} min\x1b[0m",
+                color_code, formatted_total
+            ),
+        );
+    } else {
+        println!("{:>113}", format!("Σ Total surplus: {:>4} min", 0));
     }
 
     Ok(())

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2,7 +2,7 @@ use crate::Cli;
 use crate::Commands;
 use chrono::NaiveTime;
 use r_timelog::config::Config;
-use r_timelog::utils::mins2hhmm;
+use r_timelog::utils::{mins2hhmm, print_separator};
 use r_timelog::{db, logic, utils};
 use rusqlite::Connection;
 use std::process::Command;
@@ -334,7 +334,8 @@ pub fn handle_list(period: Option<String>, db_path: &str) -> rusqlite::Result<()
         }
     }
 
-    println!("\n{:>104}", "=".repeat(25));
+    println!();
+    print_separator('-', 25, 104);
 
     if total_surplus != 0 {
         let color_code = if total_surplus < 0 {

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -206,18 +206,38 @@ pub fn handle_list(period: Option<String>, db_path: &str) -> rusqlite::Result<()
             // Only start → calculate expected end
             let expected = logic::calculate_expected_exit(&s.start, work_minutes, s.lunch);
             // \x1b[90mLunch {}\x1b[0m
+
+            let lunch_color = if s.lunch > 0 { "\x1b[0m" } else { "\x1b[90m" };
+            let lunch_str = if s.lunch > 0 {
+                mins2hhmm(s.lunch)
+            } else {
+                "-".to_string()
+            };
+            // Forza la larghezza a 5 caratteri, allineato a destra
+            let lunch_fmt = format!("{:^5}", lunch_str);
+
+            let end_color = if s.end != "" { "\x1b[0m" } else { "\x1b[90m" };
+            let end_str = if s.end != "" {
+                s.end
+            } else {
+                "-".to_string()
+            };
+            // Forza la larghezza a 5 caratteri, allineato a destra
+            let end_fmt = format!("{:^5}", end_str);
+
             println!(
-                "{:>3}: {} | Position {} | Start {} | Lunch {} | \x1b[90mEnd   -\x1b[0m   | Expected {} | \x1b[90mSurplus   -\x1b[0m",
+                "{:>3}: {} | Position {} | Start {} | {}Lunch {}\x1b[0m | {}End {}\x1b[0m | Expected {} | {}Surplus {:^8}\x1b[0m",
                 s.id,
                 s.date,
                 s.position,
                 s.start,
-                if s.lunch > 0 {
-                    mins2hhmm(s.lunch)
-                } else {
-                    "-".to_string()
-                },
+                lunch_color,
+                lunch_fmt,
+                end_color,
+                end_fmt,
                 expected.format("%H:%M"),
+                "\x1b[90m",
+                "-",
             );
         } else if has_start && has_end {
             let start_time = NaiveTime::parse_from_str(&s.start, "%H:%M").unwrap();
@@ -251,17 +271,22 @@ pub fn handle_list(period: Option<String>, db_path: &str) -> rusqlite::Result<()
                     format!("{:+}", surplus_minutes)
                 };
 
+                let lunch_str = if effective_lunch > 0 {
+                    mins2hhmm(effective_lunch)
+                } else {
+                    "-".to_string()
+                };
+
+                // Forza la larghezza a 5 caratteri, allineato a destra
+                let lunch_fmt = format!("{:^5}", lunch_str);
+
                 println!(
                     "{:>3}: {} | Position {} | Start {} | Lunch {} | End {} | Expected {} | Surplus {}{:>4} min\x1b[0m",
                     s.id,
                     s.date,
                     s.position,
                     s.start,
-                    if effective_lunch > 0 {
-                        mins2hhmm(effective_lunch)
-                    } else {
-                        "-".to_string()
-                    },
+                    lunch_fmt,
                     s.end,
                     expected.format("%H:%M"),
                     color_code,
@@ -270,30 +295,41 @@ pub fn handle_list(period: Option<String>, db_path: &str) -> rusqlite::Result<()
             } else {
                 // Case without lunch (work entirely outside the window)
                 let duration = end_time - start_time;
+                let lunch_str = "-".to_string();
+
+                // Forza la larghezza a 5 caratteri, allineato a destra
+                let lunch_fmt = format!("{:^5}", lunch_str);
+
                 println!(
-                    "{:>3}: {} | Position {} | Start {} | \x1b[90mLunch   -\x1b[0m   | End {} | \x1b[36mWorked {:>2} h {:02} min\x1b[0m",
+                    "{:>3}: {} | Position {} | Start {} | \x1b[90mLunch {}\x1b[0m | End {} | \x1b[36mWorked {:>2} h {:02} min\x1b[0m",
                     s.id,
                     s.date,
                     s.position,
                     s.start,
+                    lunch_fmt,
                     s.end,
                     duration.num_hours(),
                     duration.num_minutes() % 60
                 );
             }
         } else {
+            let lunch_str = if s.lunch > 0 {
+                mins2hhmm(s.lunch)
+            } else {
+                "-".to_string()
+            };
+
+            // Forza la larghezza a 5 caratteri, allineato a destra
+            let lunch_fmt = format!("{:^5}", lunch_str);
+
             // Incomplete information
             println!(
-                "{:>3}: {} | Position {} | Start {} | Lunch {} | End {}",
+                "{:>3}: {} | Position {} | Start {:^5} | Lunch {} | End {:^5}",
                 s.id,
                 s.date,
                 s.position,
                 if has_start { &s.start } else { "-" },
-                if s.lunch > 0 {
-                    mins2hhmm(s.lunch)
-                } else {
-                    "-".to_string()
-                },
+                lunch_fmt,
                 if has_end { &s.end } else { "-" }
             );
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,10 @@ enum Commands {
     List {
         #[arg(long, short)]
         period: Option<String>,
+
+        /// Filter by position (O=Office, R=Remote, H=Holiday)
+        #[arg(long)]
+        pos: Option<String>,
     },
 
     /// Initialize the database and configuration
@@ -123,7 +127,9 @@ fn main() -> rusqlite::Result<()> {
     match &cli.command {
         Commands::Init => commands::handle_init(&cli, &db_path),
         Commands::Add { .. } => commands::handle_add(&cli.command, &db_path),
-        Commands::List { period } => commands::handle_list(period.clone(), &db_path),
+        Commands::List { period, pos } => {
+            commands::handle_list(period.clone(), pos.clone(), &db_path)
+        }
         Commands::Conf { .. } => commands::handle_conf(&cli.command),
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -59,9 +59,15 @@ pub fn mins2hhmm(minutes: i32) -> String {
     format!("{:02}:{:02}", hours, mins)
 }
 
+/// Generate a separator string with `width` repetitions of the given `ch`,
+/// aligned to the given column (`align`).
+pub fn make_separator(ch: char, width: usize, align: usize) -> String {
+    let line = ch.to_string().repeat(width);
+    format!("{:>align$}", line, align = align)
+}
+
 /// Print a separator line with `width` repetitions of the given `ch`,
 /// aligned to the given column (`align`).
 pub fn print_separator(ch: char, width: usize, align: usize) {
-    let line = ch.to_string().repeat(width);
-    println!("{:>align$}", line, align = align);
+    println!("{}", make_separator(ch, width, align));
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -58,3 +58,10 @@ pub fn mins2hhmm(minutes: i32) -> String {
     let mins = minutes % 60;
     format!("{:02}:{:02}", hours, mins)
 }
+
+/// Print a separator line with `width` repetitions of the given `ch`,
+/// aligned to the given column (`align`).
+pub fn print_separator(ch: char, width: usize, align: usize) {
+    let line = ch.to_string().repeat(width);
+    println!("{:>align$}", line, align = align);
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -244,6 +244,92 @@ fn test_list_sessions_filter_year_month() {
 }
 
 #[test]
+fn test_list_sessions_filter_position() {
+    let db_path = setup_test_db("filter_position");
+
+    // Init DB
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "--test", "init"])
+        .assert()
+        .success();
+
+    // Add Office (O)
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "--test",
+            "add",
+            "2025-09-10",
+            "O",
+            "09:00",
+            "30",
+            "17:00",
+        ])
+        .assert()
+        .success();
+
+    // Add Remote (R)
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "--test",
+            "add",
+            "2025-09-11",
+            "R",
+            "09:15",
+            "0",
+            "17:15",
+        ])
+        .assert()
+        .success();
+
+    // Add Holiday (H)
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "--test", "add", "2025-09-12", "H"])
+        .assert()
+        .success();
+
+    // Filter O
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "--test", "list", "--pos", "O"])
+        .assert()
+        .success()
+        .stdout(contains("2025-09-10"))
+        .stdout(contains("Position O"))
+        .stdout(contains("2025-09-11").not())
+        .stdout(contains("2025-09-12").not());
+
+    // Filter R
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "--test", "list", "--pos", "R"])
+        .assert()
+        .success()
+        .stdout(contains("2025-09-11"))
+        .stdout(contains("Position R"))
+        .stdout(contains("2025-09-10").not())
+        .stdout(contains("2025-09-12").not());
+
+    // Filter H
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "--test", "list", "--pos", "H"])
+        .assert()
+        .success()
+        .stdout(contains("2025-09-12"))
+        .stdout(contains("Holiday"))
+        .stdout(contains("2025-09-10").not())
+        .stdout(contains("2025-09-11").not());
+}
+
+#[test]
 fn test_list_sessions_invalid_period() {
     let db_path = setup_test_db("invalid_period");
 

--- a/tests/utils_tests.rs
+++ b/tests/utils_tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
     use chrono::{NaiveDate, NaiveDateTime};
-    use r_timelog::utils::{date2iso, datetime2iso, iso2date, iso2datetime};
+    use r_timelog::utils::{date2iso, datetime2iso, iso2date, iso2datetime, make_separator};
 
     #[test]
     fn test_date2iso_and_iso2date() {
@@ -33,5 +33,32 @@ mod tests {
     fn test_invalid_datetime_string() {
         let invalid = "2025-09-21 14:35"; // mancano i secondi
         assert!(iso2datetime(invalid).is_err());
+    }
+
+    #[test]
+    fn test_make_separator_equal_signs() {
+        let sep = make_separator('=', 5, 10);
+        assert_eq!(sep.len(), 10); // totale = align
+        assert!(sep.ends_with("=====")); // gli ultimi 5 sono "="
+        assert!(sep.starts_with("     ")); // i primi 5 sono spazi
+    }
+
+    #[test]
+    fn test_make_separator_dollar() {
+        let sep = make_separator('$', 3, 6);
+        assert_eq!(sep, "   $$$");
+    }
+
+    #[test]
+    fn test_make_separator_dash() {
+        let sep = make_separator('-', 4, 8);
+        assert_eq!(sep, "    ----");
+    }
+
+    #[test]
+    fn test_make_separator_exact_align() {
+        // align == width → nessuno spazio davanti
+        let sep = make_separator('#', 6, 6);
+        assert_eq!(sep, "######");
     }
 }


### PR DESCRIPTION
# [0.3.1] - 2025-09-17
### Added

- New global option `--pos` in the `list` command to filter sessions by working position:
    - `O` = Office
    - `R` = Remote
    - `H` = Holiday
- A function `make_separator` and `print_separator` in `utils.rs` to generate aligned separators with custom character,
  width, and alignment.
- Unit tests for `make_separator`.
- Integration test for the new `--pos` option of `list` command.
- Display of the **total surplus** (sum of daily surpluses) at the end of the `list` output.

### Changed

- Improved the output formatting of the `list` command, including:
    - aligned `Lunch` time using `HH:MM` or padded `-`
    - cleaner separator handling with the new utility functions.
