### PR TITLE
V0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Changelog
 
+# [0.3.2] - 2025-09-17
+
+### Added
+
+- New command del to delete a work session by id from the work_sessions table.
+- New working position C = On-Site (Client).
+- Utility function to map working positions (O, R, C, H) into descriptive, colorized labels.
+- Unit test for the new utility function.
+- Integration tests for:
+    - del command (successful and unsuccessful cases).
+    - describe_position function.
+
+### Changed
+
+- Output of the list command updated:
+- Supports the new working position C=On-Site (Client).
+- Displays colorized working positions for better readability.
+- Reformatted integration test outputs for consistency.
+- Updated SQL in init command to support the new position C.
+- Introduced migration function for release 0.3.2.
+
+---
+
 # [0.3.1] - 2025-09-17
+
 ### Added
 
 - New global option `--pos` in the `list` command to filter sessions by working position:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "r_timelog"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r_timelog"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 authors = ["Umpire274 <umpire274@gmail.com>"]
 description = "A simple cross-platform CLI tool to track working hours, lunch breaks, and calculate surplus time"

--- a/README.md
+++ b/README.md
@@ -12,11 +12,21 @@ The tool calculates the expected exit time and the surplus of worked minutes.
 
 ## ✨ Features
 
-- Add work sessions with:
-    - Start time
-    - Lunch break duration
-    - End time
-    - Position (`O` = Office, `R` = Remote, `H` = Holiday)
+- Add, update, list and del work sessions.
+- Track **start time**, **lunch duration**, and **end time**.
+- Calculate **expected exit time** and **surplus** automatically.
+- Manage multiple **working positions**:
+    - `O` = **Office**
+    - `R` = **Remote**
+    - `C` = **On-Site (Client)**
+    - `H` = **Holiday**
+- Colorized output for better readability:
+    - **Blue** = Office
+    - **Cyan** = Remote
+    - **Yellow** = On-Site (Client)
+    - **Purple background + white bold** = Holiday
+- Configurable default DB path via configuration file or `--db` parameter.
+- Automatic DB migrations when upgrading the application.
 - Configurable daily working time (default `8h`)
 - Automatic expected exit calculation based on:
     - Start time
@@ -148,6 +158,24 @@ rtimelog list --pos O
 rtimelog list --pos R
 rtimelog list --pos H
 ```
+
+---
+
+Delete a session `id`
+
+Remove a session by its `id`:
+
+```bash
+rtimelog del 1
+```
+
+---
+
+## ⚠️ Notes
+
+- Lunchtime is validated: minimum 30 minutes, maximum 90 minutes for Office (O) position.
+- Holidays (H) ignore work and lunch logic, and are displayed as Holiday in purple background.
+- The --db global option allows selecting a custom database per execution, useful for testing or separate datasets.
 
 ---
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -73,6 +73,24 @@ pub fn handle_init(cli: &Cli, db_path: &str) -> rusqlite::Result<()> {
     Ok(())
 }
 
+pub fn handle_del(cmd: &Commands, db_path: &str) -> rusqlite::Result<()> {
+    if let Commands::Del { id } = cmd {
+        let conn = Connection::open(db_path)?;
+
+        match db::delete_session(&conn, *id) {
+            Ok(rows) => {
+                if rows > 0 {
+                    println!("🗑️  Session with ID {} deleted", id);
+                } else {
+                    println!("⚠️  No session found with ID {}", id);
+                }
+            }
+            Err(e) => eprintln!("❌ Error deleting session: {}", e),
+        }
+    }
+    Ok(())
+}
+
 /// Handle the `add` command
 pub fn handle_add(cmd: &Commands, db_path: &str) -> rusqlite::Result<()> {
     if let Commands::Add {

--- a/src/db.rs
+++ b/src/db.rs
@@ -78,6 +78,10 @@ pub fn add_session(
     Ok(())
 }
 
+pub fn delete_session(conn: &Connection, id: i32) -> Result<usize> {
+    conn.execute("DELETE FROM work_sessions WHERE id = ?", [id])
+}
+
 /// Return all saved work sessions, optionally filtered by year or year-month.
 pub fn list_sessions(
     conn: &Connection,

--- a/src/db.rs
+++ b/src/db.rs
@@ -22,10 +22,17 @@ pub fn init_db(conn: &Connection) -> Result<()> {
         CREATE TABLE IF NOT EXISTS work_sessions (
             id           INTEGER PRIMARY KEY AUTOINCREMENT,
             date         TEXT NOT NULL,          -- YYYY-MM-DD
-            position     TEXT NOT NULL DEFAULT 'O' CHECK (position IN ('O','R','H')),
+            position     TEXT NOT NULL DEFAULT 'O' CHECK (position IN ('O','R','H','C')),
             start_time   TEXT NOT NULL DEFAULT '',
             lunch_break  INTEGER NOT NULL DEFAULT 0,
             end_time     TEXT NOT NULL DEFAULT ''
+        );
+
+        CREATE TABLE IF NOT EXISTS log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            date TEXT NOT NULL,
+            function TEXT NOT NULL,
+            message TEXT NOT NULL
         );
         ",
     )?;

--- a/src/db/migrate.rs
+++ b/src/db/migrate.rs
@@ -19,7 +19,7 @@ fn migrate_to_030_rel(conn: &Connection) -> rusqlite::Result<()> {
     let table_sql: Option<String> = stmt.query_row([], |row| row.get(0)).optional()?;
 
     if let Some(sql) = table_sql
-        && sql.contains("CHECK (position IN ('O', 'R'))")
+        && sql.contains("CHECK (position IN ('O','R'))")
     {
         println!("⚠️  Old schema detected, migrating work_sessions to support 'H' (Holiday)...");
 
@@ -55,8 +55,51 @@ fn migrate_to_030_rel(conn: &Connection) -> rusqlite::Result<()> {
     Ok(())
 }
 
+fn migrate_to_032_rel(conn: &Connection) -> rusqlite::Result<()> {
+    let mut stmt =
+        conn.prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='work_sessions'")?;
+    let table_sql: Option<String> = stmt.query_row([], |row| row.get(0)).optional()?;
+
+    if let Some(sql) = table_sql
+        && sql.contains("CHECK(position IN ('O','R','H'))")
+    {
+        println!("⚠️  Old schema detected, migrating work_sessions to support 'C' (On-Site)...");
+
+        conn.execute_batch(
+            "
+                ALTER TABLE work_sessions RENAME TO work_sessions_old;
+
+                CREATE TABLE work_sessions (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    date TEXT NOT NULL,
+                    position TEXT NOT NULL CHECK(position IN ('O','R','H','C')),
+                    start_time TEXT DEFAULT '',
+                    lunch_break INTEGER DEFAULT 0,
+                    end_time TEXT DEFAULT ''
+                );
+
+                INSERT INTO work_sessions (id, date, position, start_time, lunch_break, end_time)
+                SELECT id, date, position, start_time, lunch_break, end_time
+                FROM work_sessions_old;
+
+                DROP TABLE work_sessions_old;
+                ",
+        )?;
+
+        db::ttlog(
+            conn,
+            "migrate_to_032_rel",
+            "Migration table \'work_sessions\' completed.",
+        )?;
+        println!("✅ Migration completed successfully.");
+    }
+
+    Ok(())
+}
+
 pub fn check_db_and_migrate(conn: &Connection) -> rusqlite::Result<()> {
     migrate_to_030_rel(conn)?;
+    migrate_to_032_rel(conn)?;
 
     Ok(())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -71,3 +71,34 @@ pub fn make_separator(ch: char, width: usize, align: usize) -> String {
 pub fn print_separator(ch: char, width: usize, align: usize) {
     println!("{}", make_separator(ch, width, align));
 }
+
+/// Return a tuple (label, colorized_label) for a given working position.
+/// O = Office (blue), R = Remote (cyan), F = On-site (yellow), H = Holiday (purple background).
+pub fn describe_position(pos: &str) -> (String, String) {
+    match pos {
+        "O" => {
+            let label = "Office".to_string();
+            let colored = "\x1b[34m".to_string();
+            (label, colored)
+        }
+        "R" => {
+            let label = "Remote".to_string();
+            let colored = "\x1b[36m".to_string();
+            (label, colored)
+        }
+        "C" => {
+            let label = "On-site (Client)".to_string();
+            let colored = "\x1b[33m".to_string();
+            (label, colored)
+        }
+        "H" => {
+            let label = "Holiday".to_string();
+            let colored = "\x1b[45;97;1m".to_string();
+            (label, colored)
+        }
+        _ => {
+            let label = pos.to_string();
+            (label.clone(), "\x1b[0m".to_string()) // fallback senza colore
+        }
+    }
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -302,7 +302,7 @@ fn test_list_sessions_filter_position() {
         .assert()
         .success()
         .stdout(contains("2025-09-10"))
-        .stdout(contains("Position O"))
+        .stdout(contains("Office"))
         .stdout(contains("2025-09-11").not())
         .stdout(contains("2025-09-12").not());
 
@@ -313,7 +313,7 @@ fn test_list_sessions_filter_position() {
         .assert()
         .success()
         .stdout(contains("2025-09-11"))
-        .stdout(contains("Position R"))
+        .stdout(contains("Remote"))
         .stdout(contains("2025-09-10").not())
         .stdout(contains("2025-09-12").not());
 
@@ -395,7 +395,7 @@ fn test_add_and_list_with_company_position() {
         .args(["--db", &db_path, "list"])
         .assert()
         .success()
-        .stdout(contains("Position O"))
+        .stdout(contains("Office"))
         .stdout(contains("Lunch 00:30"))
         .stdout(contains("Expected"))
         .stdout(contains("Surplus"));
@@ -434,7 +434,7 @@ fn test_add_and_list_with_remote_position_lunch_zero() {
         .args(["--db", &db_path, "list"])
         .assert()
         .success()
-        .stdout(contains("Position R"))
+        .stdout(contains("Remote"))
         .stdout(contains("Lunch   -"));
 }
 
@@ -462,7 +462,7 @@ fn test_add_and_list_incomplete_session() {
         .args(["--db", &db_path, "list"])
         .assert()
         .success()
-        .stdout(contains("Position O"))
+        .stdout(contains("Office"))
         .stdout(contains("Start 09:00"))
         .stdout(contains("End   -"));
 }
@@ -492,7 +492,7 @@ fn test_add_and_list_holiday_position() {
         ])
         .assert()
         .success()
-        .stdout(contains("Holiday registered"));
+        .stdout(contains("Position Holiday"));
 
     // List should show 'Holiday' as position and no more data's
     Command::cargo_bin("rtimelog")
@@ -501,4 +501,47 @@ fn test_add_and_list_holiday_position() {
         .assert()
         .success()
         .stdout(contains("Holiday"));
+}
+
+#[test]
+fn test_list_sessions_positions_with_colors() {
+    // (Position, Label atteso, Codice ANSI atteso)
+    let cases = vec![
+        ("O", "Office", "\x1b[34m"),           // Office → blu
+        ("R", "Remote", "\x1b[36m"),           // Remote → ciano
+        ("C", "On-site (Client)", "\x1b[33m"), // Client → giallo
+        ("H", "Holiday", "\x1b[45;97;1m"),     // Holiday → viola bg + bold
+    ];
+
+    for (pos, label, color) in cases {
+        let db_path = crate::setup_test_db(&format!("pos_{}", pos));
+
+        // Init DB
+        Command::cargo_bin("rtimelog")
+            .unwrap()
+            .args(["--db", &db_path, "--test", "init"])
+            .assert()
+            .success();
+
+        // Add session (Holiday non ha start/end, le altre sì)
+        let mut args = vec!["--db", &db_path, "--test", "add", "2025-09-15", pos];
+        if pos != "H" {
+            args.extend(&["09:00", "30", "17:00"]);
+        }
+
+        Command::cargo_bin("rtimelog")
+            .unwrap()
+            .args(&args)
+            .assert()
+            .success();
+
+        // List filtrato per posizione → deve contenere label e colore
+        Command::cargo_bin("rtimelog")
+            .unwrap()
+            .args(["--db", &db_path, "--test", "list", "--pos", pos])
+            .assert()
+            .success()
+            .stdout(contains(label))
+            .stdout(contains(color));
+    }
 }

--- a/tests/utils_tests.rs
+++ b/tests/utils_tests.rs
@@ -1,7 +1,9 @@
 #[cfg(test)]
 mod tests {
     use chrono::{NaiveDate, NaiveDateTime};
-    use r_timelog::utils::{date2iso, datetime2iso, iso2date, iso2datetime, make_separator};
+    use r_timelog::utils::{
+        date2iso, datetime2iso, describe_position, iso2date, iso2datetime, make_separator,
+    };
 
     #[test]
     fn test_date2iso_and_iso2date() {
@@ -60,5 +62,40 @@ mod tests {
         // align == width → nessuno spazio davanti
         let sep = make_separator('#', 6, 6);
         assert_eq!(sep, "######");
+    }
+
+    #[test]
+    fn test_describe_office() {
+        let (label, color) = describe_position("O");
+        assert_eq!(label, "Office");
+        assert_eq!(color, "\x1b[34m");
+    }
+
+    #[test]
+    fn test_describe_remote() {
+        let (label, color) = describe_position("R");
+        assert_eq!(label, "Remote");
+        assert_eq!(color, "\x1b[36m");
+    }
+
+    #[test]
+    fn test_describe_client() {
+        let (label, color) = describe_position("C");
+        assert_eq!(label, "On-site (Client)");
+        assert_eq!(color, "\x1b[33m");
+    }
+
+    #[test]
+    fn test_describe_holiday() {
+        let (label, color) = describe_position("H");
+        assert_eq!(label, "Holiday");
+        assert_eq!(color, "\x1b[45;97;1m");
+    }
+
+    #[test]
+    fn test_describe_fallback() {
+        let (label, color) = describe_position("X");
+        assert_eq!(label, "X");
+        assert_eq!(color, "\x1b[0m"); // default reset
     }
 }


### PR DESCRIPTION
# [0.3.2] - 2025-09-17

### Added

- New command del to delete a work session by id from the work_sessions table.
- New working position C = On-Site (Client).
- Utility function to map working positions (O, R, C, H) into descriptive, colorized labels.
- Unit test for the new utility function.
- Integration tests for:
    - del command (successful and unsuccessful cases).
    - describe_position function.

### Changed

- Output of the list command updated:
- Supports the new working position C=On-Site (Client).
- Displays colorized working positions for better readability.
- Reformatted integration test outputs for consistency.
- Updated SQL in init command to support the new position C.
- Introduced migration function for release 0.3.2.
