### PR TITLE
V0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 
 - The logic for expected exit time now uses configurable lunch break limits from the configuration file instead of
   hardcoded values.
+- Improved conf --edit command:
+    - If the requested editor does not exist, the application now falls back to the default editor ($EDITOR/nano on
+      Linux/macOS, notepad on Windows) instead of panicking.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+# [0.3.3] - 2025-09-18
+
+### Added
+
+- New internal DB versioning system to handle schema evolution.
+- New table schema_migrations to record each migration applied.
+- Automatic check and execution of pending migrations every time a command is run.
+- Automatic configuration file migration:
+    - Adds missing parameters min_duration_lunch_break (default 30)
+    - and max_duration_lunch_break (default 90)
+
+### Changed
+
+- The logic for expected exit time now uses configurable lunch break limits from the configuration file instead of
+  hardcoded values.
+
+---
+
 # [0.3.2] - 2025-09-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "r_timelog"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r_timelog"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 authors = ["Umpire274 <umpire274@gmail.com>"]
 description = "A simple cross-platform CLI tool to track working hours, lunch breaks, and calculate surplus time"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The tool calculates the expected exit time and the surplus of worked minutes.
 
 ## ✨ Features
 
-- Add, update, list and del work sessions.
+- Add, update, delete and list work sessions.
 - Track **start time**, **lunch duration**, and **end time**.
 - Calculate **expected exit time** and **surplus** automatically.
 - Manage multiple **working positions**:
@@ -26,7 +26,7 @@ The tool calculates the expected exit time and the surplus of worked minutes.
     - **Yellow** = On-Site (Client)
     - **Purple background + white bold** = Holiday
 - Configurable default DB path via configuration file or `--db` parameter.
-- Automatic DB migrations when upgrading the application.
+- Automatic DB migrations with version tracking (`schema_migrations` table).
 - Configurable daily working time (default `8h`)
 - Automatic expected exit calculation based on:
     - Start time
@@ -171,6 +171,86 @@ rtimelog del 1
 
 ---
 
+## ⚙️ Configuration
+
+When you run rtimelog init, a configuration file is created in your home directory:
+
+- **Linux/macOS**: `$HOME/.rtimelog/rtimelog.conf`
+- **Windows**: `%APPDATA%\rtimelog\rtimelog.conf`
+
+### Example rtimelog.conf
+
+```yaml
+database: "/home/user/.rtimelog/rtimelog.sqlite"
+default_position: "O"
+min_duration_lunch_break: 30
+max_duration_lunch_break: 90
+```
+
+**Parameters**:
+
+- database: path of the SQLite database used by the application.
+- default_position: default working position (O, R, C, H).
+- min_duration_lunch_break: minimum lunch break in minutes (default: 30).
+- max_duration_lunch_break: maximum lunch break in minutes (default: 90).
+
+### Print the current configuration
+
+You can print the absolute path of the configuration file and its contents with:
+
+```bash
+rtimelog conf --print
+```
+
+Output example:
+
+```vbnet
+📄 Config file: /home/user/.rtimelog/rtimelog.conf
+database: "/home/user/.rtimelog/rtimelog.sqlite"
+default_position: "O"
+min_duration_lunch_break: 30
+max_duration_lunch_break: 90
+```
+
+### Edit the configuration
+
+You can edit the configuration file directly from the CLI:
+
+- With the default editor of your platform:
+  ```bash
+  rtimelog conf --edit
+  ```
+- With a specific editor (e.g. `vi`):
+  ```bash
+  rtimelog conf --edit --editor vi
+  ```
+
+If the requested editor is not available on the platform, the file will be opened with the default system editor.
+
+⚠️ On **Linux/macOS**, the default editor is taken from the `$EDITOR` environment variable.
+If `$EDITOR` is not set, the system default editor will be used.
+
+⚠️ On **Windows**, if you want to use an editor installed under `Program Files` (e.g. `Notepad++`), you must provide the
+**absolute path** in quotes:
+
+```ps
+rtimelog conf --edit --editor "C:\Program Files\Notepad++\notepad++.exe"
+```
+
+---
+
+## 🗄️ Database migrations
+
+Starting from **v0.3.3**, `rTimelog` manages its own internal DB versioning:
+
+- A dedicated table `schema_migrations` tracks all migrations applied.
+- On every command execution (`init`, `add`, `list`, `del`), the application checks if the database schema is outdated.
+- If pending migrations are found, they are applied automatically before continuing.
+
+This ensures that older databases remain compatible with newer versions of the application without manual intervention.
+
+---
+
 ## ⚠️ Notes
 
 - Lunchtime is validated: minimum 30 minutes, maximum 90 minutes for Office (O) position.
@@ -179,22 +259,22 @@ rtimelog del 1
 
 ---
 
-### Show configuration file path
-
-```bash
-rtimelog conf --print
-```
-
----
-
 ## 📊 Output example
 
 ```
 📅 Saved sessions for September 2025:
-  1: 2025-09-01 | Position O | Start 09:00 | Lunch 00:45 | End 17:30 | Expected 17:45 | Surplus -15 min
-  2: 2025-09-02 | Position R | Start 08:45 | Lunch 00:00 | End 17:15 | Expected 16:45 | Surplus +30 min
-  3: 2025-09-14 | Holiday
-```
+  1: 2025-09-01 | Remote           | Start 09:08 | Lunch 00:30 | End 17:30 | Expected 17:14 | Surplus  +16 min
+  2: 2025-09-04 | Office           | Start 09:35 | Lunch 00:30 | End 17:44 | Expected 17:41 | Surplus   +3 min
+  3: 2025-09-05 | Remote           | Start 09:11 | Lunch 00:30 | End 17:01 | Expected 17:17 | Surplus  -16 min
+  4: 2025-09-11 | Remote           | Start 08:08 | Lunch   -   | End 12:16 | Worked  4 h 08 min
+  5: 2025-09-17 | Office           | Start 09:42 | Lunch 00:30 | End 17:28 | Expected 17:48 | Surplus  -20 min
+  6: 2025-09-18 | Remote           | Start 10:50 | Lunch   -   | End   -   | Expected 18:56 | Surplus    -
+  7: 2025-09-19 | Holiday          | Start   -   | Lunch   -   | End   -   | Expected   -   | Surplus    - min
+  8: 2025-09-22 | Holiday          | Start   -   | Lunch   -   | End   -   | Expected   -   | Surplus    - min
+ 
+                                                                                     -------------------------
+                                                                                     Σ Total surplus:  -17 min
+ ```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -225,10 +225,10 @@ You can edit the configuration file directly from the CLI:
   rtimelog conf --edit --editor vi
   ```
 
-If the requested editor is not available on the platform, the file will be opened with the default system editor.
+If the requested editor is not available on the platform, the file will be opened with the **default system editor**.
 
 ⚠️ On **Linux/macOS**, the default editor is taken from the `$EDITOR` environment variable.
-If `$EDITOR` is not set, the system default editor will be used.
+If `$EDITOR` is not set, the system default editor (e.g. `nano`) will be used.
 
 ⚠️ On **Windows**, if you want to use an editor installed under `Program Files` (e.g. `Notepad++`), you must provide the
 **absolute path** in quotes:

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -185,6 +185,7 @@ pub fn handle_list(
     period: Option<String>,
     pos: Option<String>,
     db_path: &str,
+    config: &Config,
 ) -> rusqlite::Result<()> {
     let conn = Connection::open(db_path)?;
     db::run_pending_migrations(&conn)?;
@@ -273,7 +274,7 @@ pub fn handle_list(
 
             // Compute effective lunch
             let effective_lunch =
-                logic::effective_lunch_minutes(s.lunch, &s.start, &s.end, pos_char);
+                logic::effective_lunch_minutes(s.lunch, &s.start, &s.end, pos_char, config);
 
             if crosses_lunch && effective_lunch > 0 {
                 // Case with lunch (inserted or automatic)

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,17 @@ pub struct Config {
     pub database: String,
     pub default_position: String,
     pub min_work_duration: String,
+    #[serde(default = "default_min_lunch")]
+    pub min_duration_lunch_break: i32,
+    #[serde(default = "default_max_lunch")]
+    pub max_duration_lunch_break: i32,
+}
+
+fn default_min_lunch() -> i32 {
+    30
+}
+fn default_max_lunch() -> i32 {
+    90
 }
 
 impl Config {
@@ -45,6 +56,8 @@ impl Config {
                 database: Self::database_file().to_string_lossy().to_string(),
                 default_position: "O".to_string(),
                 min_work_duration: "8h".to_string(),
+                min_duration_lunch_break: 30,
+                max_duration_lunch_break: 90,
             }
         }
     }
@@ -70,6 +83,8 @@ impl Config {
             database: db_path.to_string_lossy().to_string(),
             default_position: "O".to_string(),
             min_work_duration: "8h".to_string(),
+            min_duration_lunch_break: 30,
+            max_duration_lunch_break: 90,
         };
 
         // Write config file

--- a/src/logic.rs
+++ b/src/logic.rs
@@ -1,3 +1,4 @@
+use crate::config::Config;
 use chrono::{Duration, NaiveTime};
 
 pub fn month_name(month: &str) -> &'static str {
@@ -71,18 +72,27 @@ pub fn crosses_lunch_window(start: &str, end: &str) -> bool {
 /// - `A` (office): if the interval overlaps 12:30–14:30, lunch is mandatory [30..90].
 ///   If missing (0) it defaults to 30. Outside the window, lunch = 0.
 /// - `R` (remote): lunch is optional, 0..90 accepted, even if overlapping the window.
-pub fn effective_lunch_minutes(lunch: i32, start: &str, end: &str, position: char) -> i32 {
+pub fn effective_lunch_minutes(
+    lunch: i32,
+    start: &str,
+    end: &str,
+    position: char,
+    config: &Config,
+) -> i32 {
     let crosses = crosses_lunch_window(start, end);
     match position {
         'O' => {
             if crosses {
-                let l = lunch.clamp(0, 90);
+                let l = lunch.clamp(
+                    config.min_duration_lunch_break,
+                    config.max_duration_lunch_break,
+                );
                 if l < 30 { 30 } else { l }
             } else {
                 0
             }
         }
-        'R' => lunch.clamp(0, 90),
+        'H' => 0,
         _ => lunch.clamp(0, 90),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,5 @@
 use clap::{Parser, Subcommand};
 use r_timelog::config::Config;
-use r_timelog::db;
-use rusqlite::Connection;
 
 mod commands;
 
@@ -119,11 +117,6 @@ fn main() -> rusqlite::Result<()> {
         // Produzione: carica dal file di configurazione
         Config::load().database
     };
-
-    // 🔧 Workflow: controlla ed eventualmente migra lo schema
-    let conn = Connection::open(&db_path)?;
-    db::check_db_and_migrate(&conn)?;
-    drop(conn);
 
     println!();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,6 +96,8 @@ enum Commands {
 fn main() -> rusqlite::Result<()> {
     let cli = Cli::parse();
 
+    let config = Config::load();
+
     // Choose DB path: --db overrides config
     let db_path = if let Some(custom) = &cli.db {
         let custom_path = std::path::Path::new(custom);
@@ -126,7 +128,7 @@ fn main() -> rusqlite::Result<()> {
         Commands::Add { .. } => commands::handle_add(&cli.command, &db_path),
         Commands::Del { .. } => commands::handle_del(&cli.command, &db_path),
         Commands::List { period, pos } => {
-            commands::handle_list(period.clone(), pos.clone(), &db_path)
+            commands::handle_list(period.clone(), pos.clone(), &db_path, &config)
         }
     }
 }


### PR DESCRIPTION
# [0.3.3] - 2025-09-18

### Added

- New internal DB versioning system to handle schema evolution.
- New table schema_migrations to record each migration applied.
- Automatic check and execution of pending migrations every time a command is run.
- Automatic configuration file migration:
    - Adds missing parameters min_duration_lunch_break (default 30)
    - and max_duration_lunch_break (default 90)

### Changed

- The logic for expected exit time now uses configurable lunch break limits from the configuration file instead of
  hardcoded values.
- Improved conf --edit command:
    - If the requested editor does not exist, the application now falls back to the default editor ($EDITOR/nano on
      Linux/macOS, notepad on Windows) instead of panicking.
