### PR TITLE
V0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+# [0.3.6] - 2025-09-30
+
+### Added
+
+- New `log` subcommand with the `--print` option to display rows from the internal `log` table (date, function, message). Useful for diagnostics and auditing internal operations.
+
+---
+
 # [0.3.5] - 2025-09-30
 
 ### Added / Optimized

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "r_timelog"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r_timelog"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2024"
 authors = ["Umpire274 <umpire274@gmail.com>"]
 description = "A simple cross-platform CLI tool to track working hours, lunch breaks, and calculate surplus time"

--- a/README.md
+++ b/README.md
@@ -10,12 +10,9 @@ The tool calculates the expected exit time and the surplus of worked minutes.
 
 ---
 
-## What's new in v0.3.5
+## What's new in v0.3.6
 
-- Fixed: resolved a compilation issue in the configuration migration that could cause a build failure on some platforms; the config migration now correctly serializes and writes back added keys.
-- The `add` command now prints only the record that was inserted or updated, making confirmation immediate and concise.
-- Project includes configuration files for GitHub Copilot: `copilot-custom.json` (machine-readable) and `copilot-custom.md` (human-readable documentation).
-- Documentation updated: README.md now documents the `separator_char` configuration option and how to override it.
+- Added: new `log` subcommand with `--print` to display rows from the internal `log` table for debugging and audit purposes.
 
 ---
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,14 @@ enum Commands {
         )]
         editor: Option<String>,
     },
+
+    /// Print or manage the internal log table
+    Log {
+        /// Print rows from the internal `log` table
+        #[arg(long = "print", help = "Print rows from the internal log table")]
+        print: bool,
+    },
+
     /// Add or update a work session
     Add {
         /// Date (YYYY-MM-DD)
@@ -98,9 +106,8 @@ enum Commands {
 fn main() -> rusqlite::Result<()> {
     let cli = Cli::parse();
 
-    let config = Config::load();
-
-    // Choose DB path: --db overrides config
+    // Determine DB path without loading the full config (Config::load may read files under
+    // $HOME or %APPDATA% which tests may control); prefer to avoid reading it when --test is set.
     let db_path = if let Some(custom) = &cli.db {
         let custom_path = std::path::Path::new(custom);
         if custom_path.is_absolute() {
@@ -112,14 +119,33 @@ fn main() -> rusqlite::Result<()> {
                 .to_string()
         }
     } else if cli.test {
-        // In test mode: usa comunque il file di default ma NON chiama Config::load()
+        // In test mode: use the default file name under the test config dir, but DO NOT call Config::load()
         Config::config_dir()
             .join("rtimelog.sqlite")
             .to_string_lossy()
             .to_string()
     } else {
-        // Produzione: usa la configurazione già caricata
+        // Production: load the configuration and use the database path from it
+        let config = Config::load();
         config.database.clone()
+    };
+
+    // Now prepare a `config` object for use by commands; when running under --test or when --db is
+    // provided we construct a default config (matching Config::load() defaults) and point its
+    // `database` to the resolved db_path. Only when neither `--db` nor `--test` are used we call
+    // `Config::load()` to read possible overrides from disk.
+    let config = if cli.test || cli.db.is_some() {
+        Config {
+            database: db_path.clone(),
+            default_position: "O".to_string(),
+            min_work_duration: "8h".to_string(),
+            min_duration_lunch_break: 30,
+            max_duration_lunch_break: 90,
+            separator_char: "-".to_string(),
+        }
+    } else {
+        // For production we load the configuration from disk.
+        Config::load()
     };
 
     println!();
@@ -140,6 +166,7 @@ fn main() -> rusqlite::Result<()> {
 
     match &cli.command {
         Commands::Conf { .. } => commands::handle_conf(&cli.command),
+        Commands::Log { .. } => commands::handle_log(&cli.command, &conn),
         Commands::Add { .. } => commands::handle_add(&cli.command, &conn, &config),
         Commands::Del { .. } => commands::handle_del(&cli.command, &conn),
         Commands::List { period, pos } => {


### PR DESCRIPTION
# [0.3.6] - 2025-09-30

### Added

- New `log` subcommand with the `--print` option to display rows from the internal `log` table (date, function, message). Useful for diagnostics and auditing internal operations.
