### PR TITLE
V0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+# [0.4.0] - 2025-10-02
+
+### Added
+
+- Event pair aggregation features:
+  - Derived **Pair** column when listing events (sequential pairing of `in` with next `out` per date, FIFO).
+  - `--pairs <id>` filter to show only events (or summaries) for a specific pair id.
+  - `--summary` mode (only with `--events`) to display one aggregated row per pair (start, end, lunch, net duration, unmatched flag).
+  - Enriched JSON output (`--events --json` and `--events --summary --json`) including fields: `pair`, `unmatched`, `lunch_minutes`, `duration_minutes` (summary mode).
+- Unmatched event handling: lone `in` or `out` events are marked with an asterisk (`*`) after the pair id and `"unmatched": true` in JSON.
+- Case‑insensitive normalization for `--pos` filter when listing events/sessions (`r` / `R` behave the same).
+- Automatic dual-write: `add --in/--out` now (still) logs legacy session data and inserts punch events used by the new reporting features.
+- New integration tests covering:
+  - Pair calculation and filtering
+  - Summary (basic, filtered, JSON, unmatched)
+  - Enriched JSON schema
+  - Case-insensitive position filter for events
+
+### Changed
+
+- Refactored event printing logic into helper functions (`compute_event_pairs`, `compute_event_summaries`, summary/table printers).
+- Improved output alignment for event and summary tables.
+- Internal minor cleanups (pattern matching adjustments for 2024 edition, separator printing, warning removal).
+
+### Fixed
+
+- Proper representation of unmatched events; they no longer appear merged with unrelated pairs.
+- Prevented spurious formatting warnings in summary table output.
+
+### Notes
+
+- No breaking schema changes: all new capabilities are additive and backward‑compatible with existing databases.
+- Legacy session listing (`list`) remains unchanged; new functionality is activated only with `--events`.
+
+---
+
 # [0.3.6] - 2025-09-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "r_timelog"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,7 @@ dependencies = [
  "predicates",
  "rusqlite",
  "serde",
+ "serde_json",
  "serde_yaml",
 ]
 
@@ -533,6 +534,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r_timelog"
-version = "0.3.6"
+version = "0.4.0"
 edition = "2024"
 authors = ["Umpire274 <umpire274@gmail.com>"]
 description = "A simple cross-platform CLI tool to track working hours, lunch breaks, and calculate surplus time"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,4 @@ predicates = "3.1.3"
 assert_cmd = "2.0.17"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_yaml = "0.9.33"
+serde_json = "1.0.145"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,99 @@ The tool calculates the expected exit time and the surplus of worked minutes.
 
 ---
 
-## What's new in v0.3.6
+## What's new in v0.4.0
+
+**Punch events & advanced reporting**
+
+This release introduces a new internal `events` layer (punches) with powerful filtering and aggregation:
+
+| Feature | Description |
+|---------|-------------|
+| `--events` | Lists raw punch events (in/out) with a derived `Pair` column. |
+| `--pairs <id>` | Filters events (or summaries) to a specific pair id (per date). |
+| `--summary` | Aggregates events into one row per pair: start, end, lunch, net duration. |
+| `--json` | Structured JSON output (raw events or summary) including `pair` & `unmatched`. |
+| Unmatched handling | Lone `in` or `out` events marked with asterisk (`1*`) and `unmatched: true` in JSON. |
+| Case-insensitive position | `--pos r` equals `--pos R` for both sessions and events. |
+
+### Pair logic
+Pairs are assigned **per date** using FIFO pairing: the first `in` matches the first subsequent `out`. Numbering restarts for each day. Any unmatched `in` or `out` becomes its own pair and is flagged *unmatched*.
+
+### Dual write compatibility
+The `add` command continues to maintain the legacy `work_sessions` table, while also emitting events used by the new reporting flags. Existing scripts relying on `list` (without `--events`) keep working unchanged.
+
+### Example quick tour
+```bash
+# Detailed events (raw punches)
+rtimelog list --events
+
+# Same, JSON
+rtimelog list --events --json
+
+# Only remote events (case-insensitive)
+rtimelog list --events --pos r
+
+# Summarized per pair (start/end/lunch/duration)
+rtimelog list --events --summary
+
+# Summarized only pair 2
+rtimelog list --events --summary --pairs 2
+
+# JSON summary
+rtimelog list --events --summary --json
+```
+
+### Sample (events table)
+```
+📅 All events:
+ID  Date        Time   Kind  Pos  Lunch  Src   Pair
+--  ----------  -----  ----  ---  -----  ----- ----
+1   2025-12-01  09:00  in    O        0  cli      1
+2   2025-12-01  12:00  out   O       30  cli      1
+3   2025-12-01  13:00  in    O        0  cli      2
+4   2025-12-01  17:00  out   O        0  cli      2
+```
+
+### Sample (summary mode)
+```
+📊 Event pairs summary:
+Date        Pair  Pos  Start  End    Lunch  Dur
+----------  ----  ---  -----  -----  -----  ---
+2025-12-01  1     O    09:00  12:00     30  150
+2025-12-01  2     O    13:00  17:00      0  240
+```
+*Dur = net worked minutes (lunch deducted if present).*  
+*Unmatched rows would display `1*` (asterisk) and have `duration_minutes = 0` if incomplete.*
+
+### Sample JSON (summary)
+```json
+[
+  {
+    "date": "2025-12-01",
+    "pair": 1,
+    "position": "O",
+    "start": "09:00",
+    "end": "12:00",
+    "lunch_minutes": 30,
+    "duration_minutes": 150,
+    "unmatched": false
+  },
+  {
+    "date": "2025-12-01",
+    "pair": 2,
+    "position": "O",
+    "start": "13:00",
+    "end": "17:00",
+    "lunch_minutes": 0,
+    "duration_minutes": 240,
+    "unmatched": false
+  }
+]
+```
+
+---
+
+## What's new in v0.3.6 *(previous)*
 
 - Added: new `log` subcommand with `--print` to display rows from the internal `log` table for debugging and audit purposes.
 
@@ -33,7 +125,7 @@ The tool calculates the expected exit time and the surplus of worked minutes.
     - **Purple background + white bold** = Holiday
 - Configurable default DB path via configuration file or `--db` parameter.
 - Automatic DB migrations with version tracking (`schema_migrations` table).
-- Configurable daily working time (default `8h`)
+- Configurable daily working time (`min_work_duration`, default `8h`).
 - Automatic expected exit calculation based on:
     - Start time
     - Lunch break duration
@@ -43,7 +135,8 @@ The tool calculates the expected exit time and the surplus of worked minutes.
     - Maximum 1h 30m
     - Required only for `Office` position (`O`)
 - View surplus/deficit of worked time compared to expected
-- Display of the **total surplus** (sum of daily surplus/deficit) at the end of the `list` output.
+- Display of the **total surplus** at the bottom of `list` output.
+- **Event mode** with: Pair grouping, per-pair summary, JSON enrichment, unmatched detection, filtering by position & pair id.
 - Automatic database migration for schema changes
 - Cross-platform configuration file management:
     - Linux/macOS: `$HOME/.rtimelog/rtimelog.conf`
@@ -60,22 +153,27 @@ rtimelog init
 ```
 
 a configuration file is created in the user’s config directory (`rtimelog.conf`).  
-It includes:
+It includes for current releases (≥ 0.4.0):
 
 ```yaml
 database: /home/user/.rtimelog/rtimelog.sqlite
 default_position: O
-working_time: 8h
+min_work_duration: 8h
+min_duration_lunch_break: 30
+max_duration_lunch_break: 90
+separator_char: "-"
 ```
 
+Key fields:
 - **database** → path to the SQLite DB file
-- **default_position** → default working position (`O` = Office, `R` = Remote, `H` = Holiday)
-- **working_time** → daily expected working time, e.g.:
-    - `8h`
-    - `7h 36m`
+- **default_position** → default working position (`O`, `R`, `C`, `H`)
+- **min_work_duration** → daily expected working time (e.g. `7h 36m`, `8h`)
+- **min_duration_lunch_break** / **max_duration_lunch_break** → lunch constraints (minutes)
+- **separator_char** → character used for month-end separator lines
 
-You can override the DB path at runtime with the global option:
+> NOTE: Older docs referenced `working_time`; it has been unified as `min_work_duration`.
 
+Override DB path at runtime:
 ```bash
 rtimelog --db /custom/path/mydb.sqlite <command>
 ```
@@ -85,35 +183,25 @@ rtimelog --db /custom/path/mydb.sqlite <command>
 ## 🖥️ Usage
 
 ### Initialize DB and config
-
 ```bash
 rtimelog init
 ```
-
-With custom DB name:
-
+Custom DB file relative to config dir:
 ```bash
 rtimelog --db mydb.sqlite init
 ```
-
-With absolute path (spaces allowed):
-
+Absolute path:
 ```bash
 rtimelog --db "G:/My Drive/Work/Timelog/rtimelog.sqlite" init
 ```
 
----
-
-### Add work session (full)
-
+### Add a full work session
 ```bash
 rtimelog add 2025-09-13 O 09:00 60 17:30
 ```
+Creates or updates the legacy session AND adds two events (in/out) for reporting.
 
----
-
-### Add work session (partial updates)
-
+### Partial updates (each creates/updates events when relevant)
 ```bash
 rtimelog add 2025-09-13 --pos R
 rtimelog add 2025-09-13 --in 09:00
@@ -121,152 +209,75 @@ rtimelog add 2025-09-13 --lunch 45
 rtimelog add 2025-09-13 --out 17:30
 ```
 
----
-
 ### Add holiday
-
 ```bash
 rtimelog add 2025-09-14 --pos H
 ```
 
-Output with purple background:
-
-```
-  5: 2025-09-14 | Holiday
-```
-
----
-
-### List sessions
-
-All:
-
+### List sessions (legacy view)
 ```bash
-rtimelog list
+rtimelog list                # all
+rtimelog list --period 2025  # year
+rtimelog list --period 2025-09  # year-month
+rtimelog list --pos o        # position (case-insensitive)
 ```
 
-By year:
-
+### List raw events
 ```bash
-rtimelog list --period 2025
+rtimelog list --events
+rtimelog list --events --pos r          # filter by position
+rtimelog list --events --pairs 2        # only pair 2 (per date)
+rtimelog list --events --json           # raw JSON with pair & unmatched
 ```
 
-By year and month:
-
+### Summarize events per pair
 ```bash
-rtimelog list --period 2025-09
+rtimelog list --events --summary
+rtimelog list --events --summary --pairs 1
+rtimelog list --events --summary --json
 ```
 
-For working position (O, R, H). You can specify the position in either uppercase or lowercase:
-
-```bash
-rtimelog list --pos O
-rtimelog list --pos R
-rtimelog list --pos H
-```
-
----
-
-Delete a session `id`
-
-Remove a session by its `id`:
-
+### Delete a session by id
 ```bash
 rtimelog del 1
 ```
 
+### Internal log
+```bash
+rtimelog log --print
+```
+
 ---
 
-## ⚙️ Configuration
+## Event mode – behavior details
+- **Pair numbering** restarts each date.
+- **Unmatched** rows (only `in` or only `out`) show `*` and `duration_minutes = 0` in summary.
+- **Lunch minutes** shown on the `out` event (and propagated to summary) if provided or auto-deduced.
+- **Filtering precedence**: `--pairs` applies *after* computing pairs; combining with `--summary` reduces summary rows.
+- **JSON schemas**:
+  - Raw events: fields from DB + `pair`, `unmatched`.
+  - Summary: `date, pair, position, start, end, lunch_minutes, duration_minutes, unmatched`.
 
-When you run rtimelog init, a configuration file is created in your home directory:
+---
 
-- **Linux/macOS**: `$HOME/.rtimelog/rtimelog.conf`
-- **Windows**: `%APPDATA%\rtimelog\rtimelog.conf`
-
-### Example rtimelog.conf
-
-```yaml
-database: "/home/user/.rtimelog/rtimelog.sqlite"
-default_position: "O"
-min_duration_lunch_break: 30
-max_duration_lunch_break: 90
-```
-
-**Parameters**:
-
-- database: path of the SQLite database used by the application.
-- default_position: default working position (O, R, C, H).
-- min_duration_lunch_break: minimum lunch break in minutes (default: 30).
-- max_duration_lunch_break: maximum lunch break in minutes (default: 90).
-
-### Print the current configuration
-
-You can print the absolute path of the configuration file and its contents with:
-
-```bash
-rtimelog conf --print
-```
-
-Output example:
-
-```vbnet
-📄 Config file: /home/user/.rtimelog/rtimelog.conf
-database: "/home/user/.rtimelog/rtimelog.sqlite"
-default_position: "O"
-min_duration_lunch_break: 30
-max_duration_lunch_break: 90
-```
-
-### Edit the configuration
-
-You can edit the configuration file directly from the CLI:
-
-- With the default editor of your platform:
-  ```bash
-  rtimelog conf --edit
-  ```
-- With a specific editor (e.g. `vi`):
-  ```bash
-  rtimelog conf --edit --editor vi
-  ```
-
-If the requested editor is not available on the platform, the file will be opened with the **default system editor**.
-
-⚠️ On **Linux/macOS**, the default editor is taken from the `$EDITOR` environment variable.
-If `$EDITOR` is not set, the system default editor (e.g. `nano`) will be used.
-
-⚠️ On **Windows**, if you want to use an editor installed under `Program Files` (e.g. `Notepad++`), you must provide the
-**absolute path** in quotes:
-
-```ps
-rtimelog conf --edit --editor "C:\Program Files\Notepad++\notepad++.exe"
-```
+## ⚙️ Configuration (duplicate quick ref)
+(See above primary configuration section.)
 
 ---
 
 ## 🗄️ Database migrations
-
-Starting from **v0.3.3**, `rTimelog` manages its own internal DB versioning:
-
-- A dedicated table `schema_migrations` tracks all migrations applied.
-- On every command execution (`init`, `add`, `list`, `del`), the application checks if the database schema is outdated.
-- If pending migrations are found, they are applied automatically before continuing.
-
-This ensures that older databases remain compatible with newer versions of the application without manual intervention.
+*(unchanged – see CHANGELOG for past versions)*
 
 ---
 
 ## ⚠️ Notes
-
-- Lunchtime is validated: minimum 30 minutes, maximum 90 minutes for Office (O) position.
-- Holidays (H) ignore work and lunch logic, and are displayed as Holiday in purple background.
-- The --db global option allows selecting a custom database per execution, useful for testing or separate datasets.
+- Lunch validation: min 30, max 90 (Office only mandatory). Remote can specify 0.
+- Holidays ignore start/end/lunch; still appear in sessions listing.
+- `--db` allows isolated datasets (useful for testing).
 
 ---
 
-## 📊 Output example
-
+## 📊 Legacy session output example
 ```
 📅 Saved sessions for September 2025:
   1: 2025-09-01 | Remote           | Start 09:08 | Lunch 00:30 | End 17:30 | Expected 17:14 | Surplus  +16 min
@@ -277,129 +288,41 @@ This ensures that older databases remain compatible with newer versions of the a
   6: 2025-09-18 | Remote           | Start 10:50 | Lunch   -   | End   -   | Expected 18:56 | Surplus    -
   7: 2025-09-19 | Holiday          | Start   -   | Lunch   -   | End   -   | Expected   -   | Surplus    - min
   8: 2025-09-22 | Holiday          | Start   -   | Lunch   -   | End   -   | Expected   -   | Surplus    - min
- 
-                                                                                     -------------------------
-                                                                                     Σ Total surplus:  -17 min
- ```
+```
 
 ---
 
 ## Output formatting: month-end separator
-
-Starting from version 0.3.5, you can configure which character is used to draw the separator printed after the last day of each month in the `list` output.
-
-- Configuration key: `separator_char`
-- Default: `"-"`
-
-Example in `rtimelog.conf`:
-
-```yaml
-database: "/home/user/.rtimelog/rtimelog.sqlite"
-default_position: "O"
-min_duration_lunch_break: 30
-max_duration_lunch_break: 90
-separator_char: "#"
-```
-
-If `separator_char` is not present in the configuration file, the application migration will insert the default value automatically on first run.
+(See `separator_char` in configuration.)
 
 ---
 
 ## 🧪 Tests
-
 Run all tests:
-
 ```bash
 cargo test --all
 ```
-
-Tests include:
-
-- DB initialization
-- Adding and listing work sessions
-- Handling of holidays
-- Configurable working time
-- Migration compatibility
+Include coverage for: sessions CRUD, events pairing, summary, JSON, holidays, migrations.
 
 ---
 
 ## 📦 Installation
-
-### From source
-
 ```bash
 git clone https://github.com/umpire274/rTimelog.git
 cd rTimelog
 cargo build --release
 ```
-
-Binaries will be in `target/release/`.
-
-### Precompiled binaries
-
-Available on the [GitHub Releases](https://github.com/umpire274/rTimelog/releases) page.
+Binaries in `target/release/` or use releases page.
 
 ---
 
 ## 📜 License
-
-MIT License.  
-See [LICENSE](LICENSE) for details.
+MIT License – see [LICENSE](LICENSE).
 
 ---
 
-### Log (internal)
-
-Print the rows from the internal `log` table (date, function, message):
-
+### Internal Log Recap
 ```bash
 rtimelog log --print
 ```
-
-What is recorded
-
-- Columns: `id` (autoincrement), `date` (ISO 8601 timestamp), `function` (string), `message` (string).
-- When the application now writes to the `log` table:
-  - `init`: written when the database/config is initialized. Message examples:
-    - `Database initialized at C:\Users\...\rtimelog.sqlite`
-    - `Test DB initialized at C:\Users\...\AppData\Local\Temp\...` (when using `--test`).
-  - `add`: written when the `add` command applies changes for a date. Message format is concise and machine-friendly:
-    - `date=YYYY-MM-DD | key=val, key=val, ...`
-    - Example: `date=2025-09-30 | start=09:00, lunch=30`
-  - `del`: written when a session is deleted:
-    - Example: `Deleted session id 42`
-
-Behavioral notes
-
-- Each entry recorded by `db::ttlog` includes a timestamp (generated with `Utc::now().to_rfc3339()` — ISO 8601).
-- Writing to the `log` table is non-fatal: if the insert fails the command will still continue and a warning is printed to stderr.
-- The `log` table is intended for lightweight diagnostics and audit; messages are kept simple text to be human-readable but follow a predictable format for the `add` case.
-
-Examples
-
-1) Initialize a DB and inspect the log:
-
-```bash
-rtimelog --db /path/to/rtimelog.sqlite init
-rtimelog --db /path/to/rtimelog.sqlite log --print
-# Output example:
-#  1: 2025-09-30T12:34:56+00:00 | init | Database initialized at /path/to/rtimelog.sqlite
-```
-
-2) Add some data and inspect the log:
-
-```bash
-rtimelog --db /path/to/rtimelog.sqlite add 2025-09-30 O 09:00 30 17:00
-rtimelog --db /path/to/rtimelog.sqlite log --print
-# Possible log line:
-#  2: 2025-09-30T12:36:12+00:00 | add | date=2025-09-30 | start=09:00, lunch=30, end=17:00
-```
-
-3) Delete a session and inspect the log:
-
-```bash
-rtimelog --db /path/to/rtimelog.sqlite del 1
-rtimelog --db /path/to/rtimelog.sqlite log --print
-# Possible log line:
-#  3: 2025-09-30T12:40:00+00:00 | del | Deleted session id 1
-```
+Records concise audit lines for `init`, `add`, `del` and auto-lunch adjustments.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -138,7 +138,7 @@ pub fn handle_del(cmd: &Commands, conn: &Connection) -> rusqlite::Result<()> {
 }
 
 /// Handle the `add` command
-pub fn handle_add(cmd: &Commands, conn: &Connection, config: &Config) -> rusqlite::Result<()> {
+pub fn handle_add(cmd: &Commands, conn: &mut Connection, config: &Config) -> rusqlite::Result<()> {
     if let Commands::Add {
         date,
         pos_pos,
@@ -191,6 +191,13 @@ pub fn handle_add(cmd: &Commands, conn: &Connection, config: &Config) -> rusqlit
             db::upsert_start(conn, date, s)?;
             println!("✅ Start time {} registered for {}", s, date);
             changes.push(format!("start={}", s));
+
+            // Dual-write: also record an event (in). Pass explicit position only if provided, normalized to uppercase.
+            let event_pos_owned: Option<String> = pos.as_ref().map(|p| p.trim().to_uppercase());
+            let event_pos_ref: Option<&str> = event_pos_owned.as_deref();
+            if let Err(e) = db::add_event(conn, date, s, "in", event_pos_ref, "cli", None, config) {
+                eprintln!("⚠️ Failed to insert event (in): {}", e);
+            }
         }
 
         // Handle lunch
@@ -205,6 +212,21 @@ pub fn handle_add(cmd: &Commands, conn: &Connection, config: &Config) -> rusqlit
             db::upsert_lunch(conn, date, l)?;
             println!("✅ Lunch {} min registered for {}", l, date);
             changes.push(format!("lunch={}", l));
+
+            // Also, if there is an out event present, set its lunch_break for compatibility
+            match db::last_out_before(conn, date, "23:59") {
+                Ok(Some(out_ev)) => {
+                    if out_ev.lunch_break == 0 {
+                        if let Err(e) = db::set_event_lunch(conn, out_ev.id, l) {
+                            eprintln!("⚠️ Failed to set lunch on event {}: {}", out_ev.id, e);
+                        }
+                    }
+                }
+                Ok(None) => {
+                    // no out events; nothing to update
+                }
+                Err(e) => eprintln!("⚠️ Error while searching for last out event: {}", e),
+            }
         }
 
         // Handle end time
@@ -216,6 +238,15 @@ pub fn handle_add(cmd: &Commands, conn: &Connection, config: &Config) -> rusqlit
             db::upsert_end(conn, date, e)?;
             println!("✅ End time {} registered for {}", e, date);
             changes.push(format!("end={}", e));
+
+            // Dual-write: also record an event (out). Pass explicit position only if provided.
+            let event_pos_owned: Option<String> = pos.as_ref().map(|p| p.trim().to_uppercase());
+            let event_pos_ref: Option<&str> = event_pos_owned.as_deref();
+            if let Err(err) =
+                db::add_event(conn, date, e, "out", event_pos_ref, "cli", None, config)
+            {
+                eprintln!("⚠️ Failed to insert event (out): {}", err);
+            }
         }
 
         // Warn if no field provided
@@ -266,145 +297,218 @@ pub fn handle_list(
     period: Option<String>,
     pos: Option<String>,
     now: bool,
+    details: bool,
+    events: bool,
+    pairs: Option<usize>,
+    summary: bool,
+    _aggregate: bool,
+    json: bool,
     conn: &Connection,
     config: &Config,
 ) -> rusqlite::Result<()> {
     if now {
         // Get today's date in YYYY-MM-DD
         let today = chrono::Local::now().format("%Y-%m-%d").to_string();
-        let sessions = db::list_sessions_by_date(conn, &today)?;
-        if sessions.is_empty() {
-            println!("⚠️  No record for today.");
+
+        // If user supplied --now --events but not --details, map to details for convenience
+        if events && !details {
+            let events_today = db::list_events_by_date(conn, &today)?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&events_today).unwrap());
+                return Ok(());
+            }
+            println!(
+                "ℹ️  '--now --events' rilevato: usa '--now --details'. Mostro i dettagli degli eventi di oggi."
+            );
+            if events_today.is_empty() {
+                println!("No events for today.");
+                return Ok(());
+            }
+            print_events_table(&events_today, "Today's events");
             return Ok(());
         }
 
-        // Print a small header indicating today's records
-        println!("📅 Today's session(s):");
-
-        let mut total_surplus = 0;
-        let work_minutes = utils::parse_work_duration_to_minutes(&config.min_work_duration);
-        let sep_ch = config.separator_char.chars().next().unwrap_or('-');
-
-        for s in sessions {
-            let (pos_string, pos_color) = describe_position(s.position.as_str());
-            let has_start = !s.start.trim().is_empty();
-            let has_end = !s.end.trim().is_empty();
-
-            if has_start && !has_end {
-                let expected = logic::calculate_expected_exit(&s.start, work_minutes, s.lunch);
-
-                let lunch_color = if s.lunch > 0 { "\x1b[0m" } else { "\x1b[90m" };
-                let lunch_str = if s.lunch > 0 {
-                    mins2hhmm(s.lunch)
-                } else {
-                    "-".to_string()
-                };
-                let lunch_fmt = format!("{:^5}", lunch_str);
-
-                let end_color = if !s.end.is_empty() {
-                    "\x1b[0m"
-                } else {
-                    "\x1b[90m"
-                };
-                let end_str = if !s.end.is_empty() {
-                    s.end
-                } else {
-                    "-".to_string()
-                };
-                let end_fmt = format!("{:^5}", end_str);
-
-                println!(
-                    "{:>3}: {} | {}{:<16}\x1b[0m | Start {} | {}Lunch {}\x1b[0m | {}End {}\x1b[0m | Expected {} | \x1b[90mSurplus {:^8}\x1b[0m",
-                    s.id,
-                    s.date,
-                    pos_color,
-                    pos_string,
-                    s.start,
-                    lunch_color,
-                    lunch_fmt,
-                    end_color,
-                    end_fmt,
-                    expected.format("%H:%M"),
-                    "-",
-                );
-                if utils::is_last_day_of_month(&s.date) {
-                    print_separator(sep_ch, 25, 110);
-                }
-            } else if has_start && has_end {
-                let _start_time = NaiveTime::parse_from_str(&s.start, "%H:%M").unwrap();
-                let _end_time = NaiveTime::parse_from_str(&s.end, "%H:%M").unwrap();
-                let pos_char = s.position.chars().next().unwrap_or('O');
-                let crosses_lunch = logic::crosses_lunch_window(&s.start, &s.end);
-
-                let effective_lunch =
-                    logic::effective_lunch_minutes(s.lunch, &s.start, &s.end, pos_char, config);
-
-                if crosses_lunch && effective_lunch > 0 {
-                    let expected =
-                        logic::calculate_expected_exit(&s.start, work_minutes, effective_lunch);
-                    let surplus =
-                        logic::calculate_surplus(&s.start, effective_lunch, &s.end, work_minutes);
-                    let surplus_minutes = surplus.num_minutes();
-                    total_surplus += surplus_minutes;
-
-                    let color_code = if surplus_minutes < 0 {
-                        "\x1b[31m"
-                    } else {
-                        "\x1b[32m"
-                    };
-                    println!(
-                        "{:>3}: {} | {}{:<16}\x1b[0m | Start {} | Lunch {:^5} | End {} | Expected {} | {}Surplus {:^8}\x1b[0m",
-                        s.id,
-                        s.date,
-                        pos_color,
-                        pos_string,
-                        s.start,
-                        mins2hhmm(effective_lunch),
-                        s.end,
-                        expected.format("%H:%M"),
-                        color_code,
-                        format!("{}m", surplus_minutes),
-                    );
-                } else {
-                    let expected = logic::calculate_expected_exit(&s.start, work_minutes, s.lunch);
-                    let surplus = logic::calculate_surplus(&s.start, s.lunch, &s.end, work_minutes);
-                    let surplus_minutes = surplus.num_minutes();
-                    total_surplus += surplus_minutes;
-                    let color_code = if surplus_minutes < 0 {
-                        "\x1b[31m"
-                    } else {
-                        "\x1b[32m"
-                    };
-                    println!(
-                        "{:>3}: {} | {}{:<16}\x1b[0m | Start {} | Lunch {:^5} | End {} | Expected {} | {}Surplus {:^8}\x1b[0m",
-                        s.id,
-                        s.date,
-                        pos_color,
-                        pos_string,
-                        s.start,
-                        mins2hhmm(s.lunch),
-                        s.end,
-                        expected.format("%H:%M"),
-                        color_code,
-                        format!("{}m", surplus_minutes),
-                    );
-                }
-
-                if utils::is_last_day_of_month(&s.date) {
-                    print_separator(sep_ch, 25, 110);
-                }
-            } else {
-                // No start -> print minimal info
-                println!(
-                    "{:>3}: {} | {}{:<16}\x1b[0m | -",
-                    s.id, s.date, pos_color, pos_string
-                );
+        if details {
+            // Show today's events (details)
+            let events_today = db::list_events_by_date(conn, &today)?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&events_today).unwrap());
+                return Ok(());
             }
+            if events_today.is_empty() {
+                println!("No events for today.");
+                return Ok(());
+            }
+            print_events_table(&events_today, "Today's events");
+            return Ok(());
+        } else {
+            // Default: show today's work_sessions (aggregated)
+            let sessions = db::list_sessions_by_date(conn, &today)?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&sessions).unwrap());
+                return Ok(());
+            }
+            if sessions.is_empty() {
+                println!("No record for today.");
+                return Ok(());
+            }
+            println!("📅 Today's session(s):");
+            let mut total_surplus = 0;
+            let work_minutes = utils::parse_work_duration_to_minutes(&config.min_work_duration);
+            let sep_ch = config.separator_char.chars().next().unwrap_or('-');
+            for s in sessions {
+                let (pos_string, pos_color) = describe_position(s.position.as_str());
+                let has_start = !s.start.trim().is_empty();
+                let has_end = !s.end.trim().is_empty();
+                if has_start && !has_end {
+                    let expected = logic::calculate_expected_exit(&s.start, work_minutes, s.lunch);
+                    let lunch_color = if s.lunch > 0 { "\x1b[0m" } else { "\x1b[90m" };
+                    let lunch_str = if s.lunch > 0 {
+                        mins2hhmm(s.lunch)
+                    } else {
+                        "-".to_string()
+                    };
+                    let lunch_fmt = format!("{:^5}", lunch_str);
+                    let end_color = if !s.end.is_empty() {
+                        "\x1b[0m"
+                    } else {
+                        "\x1b[90m"
+                    };
+                    let end_str = if !s.end.is_empty() {
+                        s.end
+                    } else {
+                        "-".to_string()
+                    };
+                    println!(
+                        "{:>3}: {} | {}{:<16}\x1b[0m | Start {} | {}Lunch {}\x1b[0m | {}End {}\x1b[0m | Expected {} | \x1b[90mSurplus {:^8}\x1b[0m",
+                        s.id,
+                        s.date,
+                        pos_color,
+                        pos_string,
+                        s.start,
+                        lunch_color,
+                        lunch_fmt,
+                        end_color,
+                        end_str,
+                        expected.format("%H:%M"),
+                        "-"
+                    );
+                    if utils::is_last_day_of_month(&s.date) {
+                        print_separator(sep_ch, 25, 110);
+                    }
+                } else if has_start && has_end {
+                    let _start_time = NaiveTime::parse_from_str(&s.start, "%H:%M").unwrap();
+                    let _end_time = NaiveTime::parse_from_str(&s.end, "%H:%M").unwrap();
+                    let pos_char = s.position.chars().next().unwrap_or('O');
+                    let crosses_lunch = logic::crosses_lunch_window(&s.start, &s.end);
+                    let effective_lunch =
+                        logic::effective_lunch_minutes(s.lunch, &s.start, &s.end, pos_char, config);
+                    if crosses_lunch && effective_lunch > 0 {
+                        let expected =
+                            logic::calculate_expected_exit(&s.start, work_minutes, effective_lunch);
+                        let surplus = logic::calculate_surplus(
+                            &s.start,
+                            effective_lunch,
+                            &s.end,
+                            work_minutes,
+                        );
+                        let surplus_minutes = surplus.num_minutes();
+                        total_surplus += surplus_minutes;
+                        let color_code = if surplus_minutes < 0 {
+                            "\x1b[31m"
+                        } else {
+                            "\x1b[32m"
+                        };
+                        println!(
+                            "{:>3}: {} | {}{:<16}\x1b[0m | Start {} | Lunch {:^5} | End {} | Expected {} | {}Surplus {:^8}\x1b[0m",
+                            s.id,
+                            s.date,
+                            pos_color,
+                            pos_string,
+                            s.start,
+                            mins2hhmm(effective_lunch),
+                            s.end,
+                            expected.format("%H:%M"),
+                            color_code,
+                            format!("{}m", surplus_minutes)
+                        );
+                    } else {
+                        let expected =
+                            logic::calculate_expected_exit(&s.start, work_minutes, s.lunch);
+                        let surplus =
+                            logic::calculate_surplus(&s.start, s.lunch, &s.end, work_minutes);
+                        let surplus_minutes = surplus.num_minutes();
+                        total_surplus += surplus_minutes;
+                        let color_code = if surplus_minutes < 0 {
+                            "\x1b[31m"
+                        } else {
+                            "\x1b[32m"
+                        };
+                        println!(
+                            "{:>3}: {} | {}{:<16}\x1b[0m | Start {} | Lunch {:^5} | End {} | Expected {} | {}Surplus {:^8}\x1b[0m",
+                            s.id,
+                            s.date,
+                            pos_color,
+                            pos_string,
+                            s.start,
+                            mins2hhmm(s.lunch),
+                            s.end,
+                            expected.format("%H:%M"),
+                            color_code,
+                            format!("{}m", surplus_minutes)
+                        );
+                    }
+                    if utils::is_last_day_of_month(&s.date) {
+                        print_separator(sep_ch, 25, 110);
+                    }
+                } else {
+                    println!(
+                        "{:>3}: {} | {}{:<16}\x1b[0m | -",
+                        s.id, s.date, pos_color, pos_string
+                    );
+                }
+            }
+            println!("\nSummary surplus: {}m", total_surplus);
+            return Ok(());
         }
+    }
 
-        // Summary
-        println!("\nSummary surplus: {}m", total_surplus);
+    // not `now`: if --events present, list all events; otherwise list work_sessions (legacy)
+    if events {
+        let events_all = db::list_events_filtered(conn, period.as_deref(), pos.as_deref())?;
+        if events_all.is_empty() {
+            if json { println!("[]"); } else { println!("No events recorded."); }
+            return Ok(());
+        }
+        // Calcolo pair/unmatched una sola volta
+        let enriched = compute_event_pairs(&events_all);
+        // --summary: produci righe aggregate per coppia
+        if summary {
+            let mut summaries = compute_event_summaries(&enriched);
+            if let Some(pf) = pairs { summaries.retain(|r| r.pair == pf); }
+            if json {
+                println!("{}", serde_json::to_string_pretty(&summaries).unwrap());
+                return Ok(());
+            }
+            print_events_summary(&summaries, "Event pairs summary");
+            return Ok(());
+        }
+        // Filtro per pairs se richiesto (modalità dettagliata eventi)
+        let filtered: Vec<_> = if let Some(pfilter) = pairs { enriched.into_iter().filter(|e| e.pair == pfilter).collect() } else { enriched };
+        if json {
+            println!("{}", serde_json::to_string_pretty(&filtered).unwrap());
+            return Ok(());
+        }
+        let plain_events: Vec<db::Event> = filtered.iter().map(|ewp| ewp.event.clone()).collect();
+        let pair_map: Vec<(i32, usize, bool)> = filtered.iter().map(|ewp| (ewp.event.id, ewp.pair, ewp.unmatched)).collect();
+        print_events_table_with_pairs(&plain_events, &pair_map, "All events", pairs);
+        return Ok(());
+    }
 
+    if json {
+        // sessions listing in JSON (with filters if provided)
+        let sessions = db::list_sessions(conn, period.as_deref(), pos.as_deref())?;
+        println!("{}", serde_json::to_string_pretty(&sessions).unwrap());
         return Ok(());
     }
 
@@ -671,4 +775,293 @@ pub fn handle_log(cmd: &Commands, conn: &Connection) -> rusqlite::Result<()> {
         }
     }
     Ok(())
+}
+
+/// Struct di supporto per arricchire l'output JSON e calcoli Pair/unmatched
+#[derive(serde::Serialize, Clone)]
+struct EventWithPair {
+    #[serde(flatten)]
+    event: db::Event,
+    pair: usize,
+    unmatched: bool,
+}
+
+/// Calcola per una slice di Event i pair id (sequenza per data) ed il flag unmatched.
+/// Regole:
+///  - Ogni evento 'in' apre una nuova coppia con pair id incrementale (per data) e unmatched=true
+///  - Il primo 'out' successivo chiude la prima coppia aperta (FIFO) e diventa stesso pair, unmatched=false (anche per l'in)
+///  - Un 'out' senza 'in' precedente genera un nuovo pair id con unmatched=true
+fn compute_event_pairs(events: &[db::Event]) -> Vec<EventWithPair> {
+    use std::collections::VecDeque;
+    let mut result: Vec<EventWithPair> = Vec::with_capacity(events.len());
+    let mut current_date = String::new();
+    let mut open_in_queue: VecDeque<usize> = VecDeque::new();
+    let mut pair_counter: usize = 0;
+    for ev in events {
+        if ev.date != current_date {
+            // reset per nuova data
+            current_date = ev.date.clone();
+            open_in_queue.clear();
+            pair_counter = 0;
+        }
+        match ev.kind.as_str() {
+            "in" => {
+                pair_counter += 1;
+                result.push(EventWithPair {
+                    event: ev.clone(),
+                    pair: pair_counter,
+                    unmatched: true,
+                });
+                open_in_queue.push_back(result.len() - 1);
+            }
+            "out" => {
+                if let Some(in_idx) = open_in_queue.pop_front() {
+                    let pair_id = result[in_idx].pair;
+                    result[in_idx].unmatched = false; // match chiuso
+                    result.push(EventWithPair {
+                        event: ev.clone(),
+                        pair: pair_id,
+                        unmatched: false,
+                    });
+                } else {
+                    pair_counter += 1; // out orfano
+                    result.push(EventWithPair {
+                        event: ev.clone(),
+                        pair: pair_counter,
+                        unmatched: true,
+                    });
+                }
+            }
+            _ => {
+                pair_counter += 1;
+                result.push(EventWithPair {
+                    event: ev.clone(),
+                    pair: pair_counter,
+                    unmatched: true,
+                });
+            }
+        }
+    }
+    result
+}
+
+#[derive(serde::Serialize, Clone, Debug)]
+struct SummaryRow {
+    date: String,
+    pair: usize,
+    position: String,
+    start: String,
+    end: String,
+    lunch_minutes: i32,
+    duration_minutes: i32,
+    unmatched: bool,
+}
+
+fn compute_event_summaries(enriched: &[EventWithPair]) -> Vec<SummaryRow> {
+    use std::collections::BTreeMap;
+    #[derive(Default)]
+    struct Accum {
+        date: String,
+        pair: usize,
+        position: String,
+        start: Option<String>,
+        end: Option<String>,
+        lunch: i32,
+        unmatched_in: bool,
+        unmatched_out: bool,
+    }
+    let mut map: BTreeMap<(String, usize), Accum> = BTreeMap::new();
+    for e in enriched {
+        let key = (e.event.date.clone(), e.pair);
+        let acc = map.entry(key.clone()).or_insert_with(|| Accum { date: key.0.clone(), pair: key.1, position: String::new(), start: None, end: None, lunch: 0, unmatched_in: false, unmatched_out: false });
+        if e.event.kind == "in" {
+            if acc.start.is_none() { acc.start = Some(e.event.time.clone()); }
+            if acc.position.is_empty() { acc.position = e.event.position.clone(); }
+            if e.unmatched { acc.unmatched_in = true; }
+        } else if e.event.kind == "out" {
+            if acc.end.is_none() { acc.end = Some(e.event.time.clone()); }
+            if acc.position.is_empty() { acc.position = e.event.position.clone(); }
+            if e.event.lunch_break > 0 { acc.lunch = e.event.lunch_break; }
+            if e.unmatched { acc.unmatched_out = true; }
+        }
+    }
+    let mut rows: Vec<SummaryRow> = Vec::new();
+    for (_, acc) in map.into_iter() {
+        let unmatched = (acc.start.is_some() && acc.end.is_none()) || (acc.start.is_none() && acc.end.is_some());
+        // Calcolo durata
+        let mut duration_minutes = 0;
+        if let (Some(s), Some(e)) = (acc.start.as_ref(), acc.end.as_ref()) {
+            if let (Ok(st), Ok(et)) = (chrono::NaiveTime::parse_from_str(s, "%H:%M"), chrono::NaiveTime::parse_from_str(e, "%H:%M")) {
+                let mut diff = (et - st).num_minutes() as i32;
+                if acc.lunch > 0 { diff -= acc.lunch; }
+                if diff < 0 { diff = 0; }
+                duration_minutes = diff;
+            }
+        }
+        rows.push(SummaryRow {
+            date: acc.date,
+            pair: acc.pair,
+            position: acc.position,
+            start: acc.start.unwrap_or_else(|| "-".to_string()),
+            end: acc.end.unwrap_or_else(|| "-".to_string()),
+            lunch_minutes: acc.lunch,
+            duration_minutes,
+            unmatched,
+        });
+    }
+    rows
+}
+
+fn print_events_summary(rows: &[SummaryRow], title: &str) {
+    println!("\u{1F4CA} {}:", title);
+    if rows.is_empty() { println!("(no pairs)"); return; }
+    // Determine widths
+    let mut w_date=10usize; let mut w_pair=4usize; let mut w_pos=3usize; let mut w_start=5usize; let mut w_end=5usize; let mut w_lunch=5usize; let mut w_dur=3usize;
+    for r in rows {
+        w_date = w_date.max(r.date.len());
+        w_pair = w_pair.max(format!("{}{}", r.pair, if r.unmatched {"*"} else {""}).len());
+        w_pos = w_pos.max(r.position.len());
+        w_start = w_start.max(r.start.len());
+        w_end = w_end.max(r.end.len());
+        w_lunch = w_lunch.max(r.lunch_minutes.to_string().len());
+        w_dur = w_dur.max(r.duration_minutes.to_string().len());
+    }
+    println!(
+        "{:<date$}  {:>pair$}  {:<pos$}  {:>start$}  {:>end$}  {:>lunch$}  {:>dur$}",
+        "Date","Pair","Pos","Start","End","Lunch","Dur",
+        date=w_date,pair=w_pair,pos=w_pos,start=w_start,end=w_end,lunch=w_lunch,dur=w_dur
+    );
+    println!("{}  {}  {}  {}  {}  {}  {}",
+        "-".repeat(w_date),
+        "-".repeat(w_pair),
+        "-".repeat(w_pos),
+        "-".repeat(w_start),
+        "-".repeat(w_end),
+        "-".repeat(w_lunch),
+        "-".repeat(w_dur),
+    );
+    for r in rows {
+        let pair_disp = format!("{}{}", r.pair, if r.unmatched {"*"} else {""});
+        println!(
+            "{:<date$}  {:>pair$}  {:<pos$}  {:>start$}  {:>end$}  {:>lunch$}  {:>dur$}",
+            r.date, pair_disp, r.position, r.start, r.end, r.lunch_minutes, r.duration_minutes,
+            date=w_date,pair=w_pair,pos=w_pos,start=w_start,end=w_end,lunch=w_lunch,dur=w_dur
+        );
+    }
+}
+
+// Helper to print events in aligned table format
+fn print_events_table_with_pairs(
+    events: &[db::Event],
+    pair_map: &[(i32, usize, bool)],
+    title: &str,
+    filter_pair: Option<usize>,
+) {
+    println!("\u{1F4C5} {}:", title);
+    if events.is_empty() {
+        return;
+    }
+    // costruisce lookup id -> (pair, unmatched)
+    use std::collections::HashMap;
+    let mut meta: HashMap<i32, (usize, bool)> = HashMap::new();
+    for (id, pair, un) in pair_map {
+        meta.insert(*id, (*pair, *un));
+    }
+
+    // Determina colonne (Pair colonna con possibile suffisso *)
+    let mut w_id = 2usize;
+    let mut w_date = 10usize;
+    let mut w_time = 5usize;
+    let mut w_kind = 4usize;
+    let mut w_pos = 3usize;
+    let mut w_lunch = 5usize;
+    let mut w_src = 5usize;
+    let mut w_pair = 4usize;
+    for e in events {
+        if let Some((pair, unmatched)) = meta.get(&e.id) {
+            let tag = if *unmatched {
+                format!("{}*", pair)
+            } else {
+                pair.to_string()
+            };
+            w_pair = w_pair.max(tag.len());
+        }
+        w_id = w_id.max(e.id.to_string().len());
+        w_date = w_date.max(e.date.len());
+        w_time = w_time.max(e.time.len());
+        w_kind = w_kind.max(e.kind.len());
+        w_pos = w_pos.max(e.position.len());
+        w_lunch = w_lunch.max(e.lunch_break.to_string().len());
+        w_src = w_src.max(e.source.len());
+    }
+
+    println!(
+        "{:<id$}  {:<date$}  {:<time$}  {:<kind$}  {:<pos$}  {:>lunch$}  {:<src$}  {:>pair$}",
+        "ID",
+        "Date",
+        "Time",
+        "Kind",
+        "Pos",
+        "Lunch",
+        "Src",
+        "Pair",
+        id = w_id,
+        date = w_date,
+        time = w_time,
+        kind = w_kind,
+        pos = w_pos,
+        lunch = w_lunch,
+        src = w_src,
+        pair = w_pair
+    );
+    println!(
+        "{:-<1$}  {:-<2$}  {:-<3$}  {:-<4$}  {:-<5$}  {:-<6$}  {:-<7$}  {:-<8$}",
+        "", w_id, w_date, w_time, w_kind, w_pos, w_lunch, w_src, w_pair
+    );
+
+    for e in events {
+        if let Some(fp) = filter_pair {
+            if let Some((pair_id, _)) = meta.get(&e.id) {
+                if *pair_id != fp {
+                    continue;
+                }
+            }
+        }
+        let (pair_id, unmatched) = meta.get(&e.id).cloned().unwrap_or((0, true));
+        let pair_display = if unmatched {
+            format!("{}*", pair_id)
+        } else {
+            pair_id.to_string()
+        };
+        println!(
+            "{:<id$}  {:<date$}  {:<time$}  {:<kind$}  {:<pos$}  {:>lunch$}  {:<src$}  {:>pair$}",
+            e.id,
+            e.date,
+            e.time,
+            e.kind,
+            e.position,
+            e.lunch_break,
+            e.source,
+            pair_display,
+            id = w_id,
+            date = w_date,
+            time = w_time,
+            kind = w_kind,
+            pos = w_pos,
+            lunch = w_lunch,
+            src = w_src,
+            pair = w_pair
+        );
+    }
+}
+
+// Mantiene per retrocompatibilità la vecchia funzione ma delega alla nuova con enrich
+fn print_events_table(events: &[db::Event], title: &str) {
+    let enriched = compute_event_pairs(events);
+    let plain: Vec<db::Event> = enriched.iter().map(|e| e.event.clone()).collect();
+    let map: Vec<(i32, usize, bool)> = enriched
+        .iter()
+        .map(|e| (e.event.id, e.pair, e.unmatched))
+        .collect();
+    print_events_table_with_pairs(&plain, &map, title, None);
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -274,7 +274,7 @@ pub fn handle_list(
         let today = chrono::Local::now().format("%Y-%m-%d").to_string();
         let sessions = db::list_sessions_by_date(conn, &today)?;
         if sessions.is_empty() {
-            println!("No record for today.");
+            println!("⚠️  No record for today.");
             return Ok(());
         }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -29,6 +29,66 @@ pub struct Event {
     pub created_at: String, // ISO timestamp
 }
 
+fn row_to_worksession(row: &rusqlite::Row) -> Result<WorkSession> {
+    Ok(WorkSession {
+        id: row.get(0)?,
+        date: row.get(1)?,
+        position: row.get(2)?,
+        start: row.get(3)?,
+        lunch: row.get(4)?,
+        end: row.get(5)?,
+    })
+}
+
+fn row_to_event(row: &rusqlite::Row) -> Result<Event> {
+    Ok(Event {
+        id: row.get(0)?,
+        date: row.get(1)?,
+        time: row.get(2)?,
+        kind: row.get(3)?,
+        position: row.get(4)?,
+        lunch_break: row.get(5)?,
+        source: row.get(6)?,
+        meta: row.get(7)?,
+        created_at: row.get(8)?,
+    })
+}
+
+// Generic helper to build a query with optional filters for period and position
+fn build_filtered_query(
+    base_query: &str,
+    period: Option<&str>,
+    pos: Option<&str>,
+) -> Result<(String, Vec<String>)> {
+    let mut query = base_query.to_string();
+    let mut conditions = Vec::new();
+    let mut params: Vec<String> = Vec::new();
+
+    if let Some(p) = period {
+        if p.len() == 4 {
+            conditions.push("strftime('%Y', date) = ?".to_string());
+            params.push(p.to_string());
+        } else if p.len() == 7 {
+            conditions.push("strftime('%Y-%m', date) = ?".to_string());
+            params.push(p.to_string());
+        } else {
+            return Err(rusqlite::Error::InvalidQuery);
+        }
+    }
+
+    if let Some(pos_filter) = pos {
+        conditions.push("position = ?".to_string());
+        params.push(pos_filter.to_uppercase());
+    }
+
+    if !conditions.is_empty() {
+        query.push_str(" WHERE ");
+        query.push_str(&conditions.join(" AND "));
+    }
+
+    Ok((query, params))
+}
+
 /// Initialize the database schema.
 /// Ensures table `work_sessions` exists and adds missing `position` column if required.
 pub fn init_db(conn: &Connection) -> Result<()> {
@@ -94,89 +154,64 @@ pub fn list_sessions(
     period: Option<&str>,
     pos: Option<&str>,
 ) -> Result<Vec<WorkSession>> {
-    let mut query = String::from(
-        "SELECT id, date, position, start_time, lunch_break, end_time FROM work_sessions",
-    );
-
-    let mut conditions = Vec::new();
-    let mut params: Vec<String> = Vec::new();
-
-    if let Some(p) = period {
-        if p.len() == 4 {
-            conditions.push("strftime('%Y', date) = ?".to_string());
-            params.push(p.to_string());
-        } else if p.len() == 7 {
-            conditions.push("strftime('%Y-%m', date) = ?".to_string());
-            params.push(p.to_string());
-        } else {
-            return Err(rusqlite::Error::InvalidQuery);
-        }
-    }
-
-    if let Some(pos_filter) = pos {
-        conditions.push("position = ?".to_string());
-        params.push(pos_filter.to_string());
-    }
-
-    if !conditions.is_empty() {
-        query.push_str(" WHERE ");
-        query.push_str(&conditions.join(" AND "));
-    }
+    let base_query =
+        "SELECT id, date, position, start_time, lunch_break, end_time FROM work_sessions";
+    let (mut query, params) = build_filtered_query(base_query, period, pos)?;
 
     query.push_str(" ORDER BY date ASC");
 
-    // Use cached prepared statement to avoid recompiling the SQL on repeated calls
     let mut stmt = conn.prepare_cached(&query)?;
     let params_refs: Vec<&dyn ToSql> = params.iter().map(|s| s as &dyn ToSql).collect();
-    let rows = stmt.query_map(params_refs.as_slice(), |row| {
-        Ok(WorkSession {
-            id: row.get(0)?,
-            date: row.get(1)?,
-            position: row.get(2)?,
-            start: row.get(3)?,
-            lunch: row.get(4)?,
-            end: row.get(5)?,
-        })
-    })?;
+    let rows = stmt.query_map(params_refs.as_slice(), row_to_worksession)?;
 
-    let mut sessions = Vec::new();
-    for s in rows {
-        sessions.push(s?);
-    }
-    Ok(sessions)
+    rows.collect::<Result<Vec<_>, _>>()
 }
 
-/// Insert or update the position (A=office, R=remote) for a given date.
-pub fn upsert_position(conn: &Connection, date: &str, pos: &str) -> Result<()> {
-    let mut stmt = conn.prepare_cached("UPDATE work_sessions SET position = ?1 WHERE date = ?2")?;
-    let rows = stmt.execute(params![pos, date])?;
+/// Generic upsert helper for a single field in `work_sessions` table.
+fn upsert_field<T: ToSql>(
+    conn: &Connection,
+    date: &str,
+    field: &str,
+    value: T,
+    default_pos: &str,
+) -> Result<()> {
+    let update_sql = format!("UPDATE work_sessions SET {} = ?1 WHERE date = ?2", field);
+    let mut stmt = conn.prepare_cached(&update_sql)?;
+    let rows = stmt.execute(params![&value, date])?;
+
     if rows == 0 {
-        let mut ins = conn.prepare_cached(
-            "INSERT INTO work_sessions (date, position, start_time, lunch_break, end_time)
-             VALUES (?1, ?2, '', 0, '')",
-        )?;
-        ins.execute(params![date, pos])?;
+        let insert_sql = format!(
+            "INSERT INTO work_sessions (date, position, {}) VALUES (?1, ?2, ?3)",
+            field
+        );
+        let mut ins = conn.prepare_cached(&insert_sql)?;
+        ins.execute(params![date, default_pos, &value])?;
     }
     Ok(())
 }
 
+/// Insert or update the position (A=office, R=remote) for a given date.
+pub fn upsert_position(conn: &Connection, date: &str, pos: &str) -> Result<()> {
+    upsert_field(conn, date, "position", pos, pos)
+}
+
 /// Insert or update the start time (HH:MM) for a given date.
 pub fn upsert_start(conn: &Connection, date: &str, start: &str) -> Result<()> {
-    // Update only if start_time is empty (preserve first start of the day)
+    // Custom logic: only update if start_time is empty
     let mut stmt = conn.prepare_cached(
         "UPDATE work_sessions SET start_time = ?1 WHERE date = ?2 AND (start_time = '' OR start_time IS NULL)",
     )?;
-    let rows = stmt.execute(params![start, date])?;
-    if rows == 0 {
-        // If no existing row was updated, ensure a row exists; if not, insert with provided start
-        let mut check = conn.prepare_cached("SELECT id FROM work_sessions WHERE date = ?1")?;
-        let exists = check.query_row([date], |_| Ok(() as ())).optional()?;
-        if exists.is_none() {
-            let mut ins = conn.prepare_cached(
-                "INSERT INTO work_sessions (date, position, start_time, lunch_break, end_time)
-                 VALUES (?1, 'A', ?2, 0, '')",
-            )?;
-            ins.execute(params![date, start])?;
+    if stmt.execute(params![start, date])? == 0 {
+        let exists = conn
+            .query_row(
+                "SELECT 1 FROM work_sessions WHERE date = ?1",
+                [date],
+                |_| Ok(()),
+            )
+            .optional()?
+            .is_some();
+        if !exists {
+            upsert_field(conn, date, "start_time", start, "O")?;
         }
     }
     Ok(())
@@ -184,31 +219,12 @@ pub fn upsert_start(conn: &Connection, date: &str, start: &str) -> Result<()> {
 
 /// Insert or update the lunch break (minutes) for a given date.
 pub fn upsert_lunch(conn: &Connection, date: &str, lunch: i32) -> Result<()> {
-    let mut stmt =
-        conn.prepare_cached("UPDATE work_sessions SET lunch_break = ?1 WHERE date = ?2")?;
-    let rows = stmt.execute(params![lunch, date])?;
-    if rows == 0 {
-        let mut ins = conn.prepare_cached(
-            "INSERT INTO work_sessions (date, position, start_time, lunch_break, end_time)
-             VALUES (?1, 'A', '', ?2, '')",
-        )?;
-        ins.execute(params![date, lunch])?;
-    }
-    Ok(())
+    upsert_field(conn, date, "lunch_break", lunch, "O")
 }
 
 /// Insert or update the end time (HH:MM) for a given date.
 pub fn upsert_end(conn: &Connection, date: &str, end: &str) -> Result<()> {
-    let mut stmt = conn.prepare_cached("UPDATE work_sessions SET end_time = ?1 WHERE date = ?2")?;
-    let rows = stmt.execute(params![end, date])?;
-    if rows == 0 {
-        let mut ins = conn.prepare_cached(
-            "INSERT INTO work_sessions (date, position, start_time, lunch_break, end_time)
-             VALUES (?1, 'A', '', 0, ?2)",
-        )?;
-        ins.execute(params![date, end])?;
-    }
-    Ok(())
+    upsert_field(conn, date, "end_time", end, "O")
 }
 
 pub fn ttlog(conn: &Connection, function: &str, message: &str) -> Result<()> {
@@ -225,16 +241,7 @@ pub fn get_session(conn: &Connection, id: i32) -> Result<Option<WorkSession>> {
         "SELECT id, date, position, start_time, lunch_break, end_time FROM work_sessions WHERE id = ?1",
     )?;
 
-    match stmt.query_row([id], |row| {
-        Ok(WorkSession {
-            id: row.get(0)?,
-            date: row.get(1)?,
-            position: row.get(2)?,
-            start: row.get(3)?,
-            lunch: row.get(4)?,
-            end: row.get(5)?,
-        })
-    }) {
+    match stmt.query_row([id], row_to_worksession) {
         Ok(ws) => Ok(Some(ws)),
         Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
         Err(e) => Err(e),
@@ -245,22 +252,9 @@ pub fn get_session(conn: &Connection, id: i32) -> Result<Option<WorkSession>> {
 pub fn list_sessions_by_date(conn: &Connection, date: &str) -> Result<Vec<WorkSession>> {
     let query = "SELECT id, date, position, start_time, lunch_break, end_time FROM work_sessions WHERE date = ?1 ORDER BY date ASC";
     let mut stmt = conn.prepare_cached(query)?;
-    let rows = stmt.query_map([date], |row| {
-        Ok(WorkSession {
-            id: row.get(0)?,
-            date: row.get(1)?,
-            position: row.get(2)?,
-            start: row.get(3)?,
-            lunch: row.get(4)?,
-            end: row.get(5)?,
-        })
-    })?;
+    let rows = stmt.query_map([date], row_to_worksession)?;
 
-    let mut sessions = Vec::new();
-    for s in rows {
-        sessions.push(s?);
-    }
-    Ok(sessions)
+    rows.collect::<Result<Vec<_>, _>>()
 }
 
 /// List events for a specific date (ordered by time asc)
@@ -268,25 +262,9 @@ pub fn list_events_by_date(conn: &Connection, date: &str) -> Result<Vec<Event>> 
     let mut stmt = conn.prepare_cached(
         "SELECT id, date, time, kind, position, lunch_break, source, meta, created_at FROM events WHERE date = ?1 ORDER BY time ASC",
     )?;
-    let rows = stmt.query_map([date], |row| {
-        Ok(Event {
-            id: row.get(0)?,
-            date: row.get(1)?,
-            time: row.get(2)?,
-            kind: row.get(3)?,
-            position: row.get(4)?,
-            lunch_break: row.get(5)?,
-            source: row.get(6)?,
-            meta: row.get(7)?,
-            created_at: row.get(8)?,
-        })
-    })?;
+    let rows = stmt.query_map([date], row_to_event)?;
 
-    let mut evs = Vec::new();
-    for e in rows {
-        evs.push(e?);
-    }
-    Ok(evs)
+    rows.collect::<Result<Vec<_>, _>>()
 }
 
 /// List all events in the database ordered by date and time
@@ -294,25 +272,9 @@ pub fn list_events(conn: &Connection) -> Result<Vec<Event>> {
     let mut stmt = conn.prepare_cached(
         "SELECT id, date, time, kind, position, lunch_break, source, meta, created_at FROM events ORDER BY date ASC, time ASC",
     )?;
-    let rows = stmt.query_map([], |row| {
-        Ok(Event {
-            id: row.get(0)?,
-            date: row.get(1)?,
-            time: row.get(2)?,
-            kind: row.get(3)?,
-            position: row.get(4)?,
-            lunch_break: row.get(5)?,
-            source: row.get(6)?,
-            meta: row.get(7)?,
-            created_at: row.get(8)?,
-        })
-    })?;
+    let rows = stmt.query_map([], row_to_event)?;
 
-    let mut evs = Vec::new();
-    for e in rows {
-        evs.push(e?);
-    }
-    Ok(evs)
+    rows.collect::<Result<Vec<_>, _>>()
 }
 
 /// List events filtered by optional period (YYYY or YYYY-MM) and position
@@ -321,56 +283,16 @@ pub fn list_events_filtered(
     period: Option<&str>,
     pos: Option<&str>,
 ) -> Result<Vec<Event>> {
-    let mut query = String::from(
-        "SELECT id, date, time, kind, position, lunch_break, source, meta, created_at FROM events",
-    );
-    let mut conditions: Vec<String> = Vec::new();
-    let mut params: Vec<String> = Vec::new();
+    let base_query =
+        "SELECT id, date, time, kind, position, lunch_break, source, meta, created_at FROM events";
+    let (mut query, params) = build_filtered_query(base_query, period, pos)?;
 
-    if let Some(p) = period {
-        if p.len() == 4 {
-            // year
-            conditions.push("strftime('%Y', date) = ?".to_string());
-            params.push(p.to_string());
-        } else if p.len() == 7 {
-            // year-month
-            conditions.push("strftime('%Y-%m', date) = ?".to_string());
-            params.push(p.to_string());
-        } else {
-            return Err(rusqlite::Error::InvalidQuery);
-        }
-    }
-    if let Some(pos_filter) = pos {
-        let up = pos_filter.trim().to_uppercase();
-        conditions.push("position = ?".to_string());
-        params.push(up);
-    }
-    if !conditions.is_empty() {
-        query.push_str(" WHERE ");
-        query.push_str(&conditions.join(" AND "));
-    }
     query.push_str(" ORDER BY date ASC, time ASC");
 
     let mut stmt = conn.prepare_cached(&query)?;
     let param_refs: Vec<&dyn ToSql> = params.iter().map(|s| s as &dyn ToSql).collect();
-    let rows = stmt.query_map(param_refs.as_slice(), |row| {
-        Ok(Event {
-            id: row.get(0)?,
-            date: row.get(1)?,
-            time: row.get(2)?,
-            kind: row.get(3)?,
-            position: row.get(4)?,
-            lunch_break: row.get(5)?,
-            source: row.get(6)?,
-            meta: row.get(7)?,
-            created_at: row.get(8)?,
-        })
-    })?;
-    let mut evs = Vec::new();
-    for e in rows {
-        evs.push(e?);
-    }
-    Ok(evs)
+    let rows = stmt.query_map(param_refs.as_slice(), row_to_event)?;
+    rows.collect::<Result<Vec<_>, _>>()
 }
 
 /// Find last out event before a given time on the same date
@@ -378,19 +300,7 @@ pub fn last_out_before(conn: &Connection, date: &str, time: &str) -> Result<Opti
     let mut stmt = conn.prepare_cached(
         "SELECT id, date, time, kind, position, lunch_break, source, meta, created_at FROM events WHERE date = ?1 AND kind = 'out' AND time < ?2 ORDER BY time DESC LIMIT 1",
     )?;
-    match stmt.query_row([date, time], |row| {
-        Ok(Event {
-            id: row.get(0)?,
-            date: row.get(1)?,
-            time: row.get(2)?,
-            kind: row.get(3)?,
-            position: row.get(4)?,
-            lunch_break: row.get(5)?,
-            source: row.get(6)?,
-            meta: row.get(7)?,
-            created_at: row.get(8)?,
-        })
-    }) {
+    match stmt.query_row([date, time], row_to_event) {
         Ok(ev) => Ok(Some(ev)),
         Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
         Err(e) => Err(e),
@@ -406,17 +316,22 @@ pub fn set_event_lunch(conn: &Connection, event_id: i32, lunch: i32) -> Result<(
     Ok(())
 }
 
+pub struct AddEventArgs<'a> {
+    pub date: &'a str,
+    pub time: &'a str,
+    pub kind: &'a str,
+    pub position: Option<&'a str>,
+    pub source: &'a str,
+    pub meta: Option<&'a str>,
+}
+
 /// Insert an event and run auto-lunch logic if kind == 'in'.
 /// This function uses a transaction to ensure atomicity. It also performs dual-write
 /// to legacy `work_sessions` via existing upsert_* helpers to keep backwards compatibility.
+#[allow(clippy::too_many_arguments)]
 pub fn add_event(
     conn: &mut Connection,
-    date: &str,
-    time: &str,
-    kind: &str,
-    position: Option<&str>,
-    source: &str,
-    meta: Option<&str>,
+    args: &AddEventArgs,
     config: &crate::config::Config,
 ) -> Result<i64> {
     let tx = conn.transaction()?;
@@ -425,17 +340,17 @@ pub fn add_event(
     // - if user provided position (Some) -> use it
     // - else if kind == 'out' -> try to inherit from last 'in' on the same date
     // - otherwise fallback to config.default_position
-    let mut position_to_use = if let Some(p) = position {
+    let mut position_to_use = if let Some(p) = args.position {
         p.to_string()
     } else {
         config.default_position.clone()
     };
-    if position.is_none() && kind == "out" {
+    if args.position.is_none() && args.kind == "out" {
         let mut stmt = tx.prepare_cached(
             "SELECT position FROM events WHERE date = ?1 AND kind = 'in' AND time <= ?2 ORDER BY time DESC LIMIT 1",
         )?;
         if let Some(found_pos) = stmt
-            .query_row([date, time], |row| row.get::<_, String>(0))
+            .query_row([args.date, args.time], |row| row.get::<_, String>(0))
             .optional()?
         {
             position_to_use = found_pos;
@@ -444,59 +359,59 @@ pub fn add_event(
 
     tx.execute(
         "INSERT INTO events (date, time, kind, position, lunch_break, source, meta, created_at) VALUES (?1, ?2, ?3, ?4, 0, ?5, ?6, ?7)",
-        params![date, time, kind, position_to_use, source, meta.unwrap_or(""), Utc::now().to_rfc3339()],
+        params![args.date, args.time, args.kind, position_to_use, args.source, args.meta.unwrap_or(""), Utc::now().to_rfc3339()],
     )?;
 
     let event_id = tx.last_insert_rowid();
 
     // Dual-write to legacy table to ease rollout
-    if kind == "in" {
+    if args.kind == "in" {
         // store start in legacy place
-        let _ = upsert_start(&tx, date, time);
-    } else if kind == "out" {
-        let _ = upsert_end(&tx, date, time);
+        let _ = upsert_start(&tx, args.date, args.time);
+    } else if args.kind == "out" {
+        let _ = upsert_end(&tx, args.date, args.time);
     }
 
     // If this is an 'in' event, attempt to populate lunch on the previous 'out' (auto-lunch)
-    if kind == "in" {
-        if let Some(prev_out) = last_out_before(&tx, date, time)? {
-            // Exclude holiday positions
-            if prev_out.position != "H" && position_to_use != "H" {
-                // Ensure previous out has no lunch yet
-                if prev_out.lunch_break == 0 {
-                    // Parse times
-                    if let (Ok(prev_time), Ok(new_time)) = (
-                        NaiveTime::parse_from_str(&prev_out.time, "%H:%M"),
-                        NaiveTime::parse_from_str(time, "%H:%M"),
-                    ) {
-                        let noon = NaiveTime::from_hms_opt(12, 0, 0).unwrap();
-                        let latest = NaiveTime::from_hms_opt(14, 30, 0).unwrap();
-                        if prev_time >= noon && new_time <= latest && new_time > prev_time {
-                            let delta = (new_time - prev_time).num_minutes() as i32;
-                            let mut lunch_val = delta;
-                            if lunch_val < config.min_duration_lunch_break {
-                                lunch_val = config.min_duration_lunch_break;
-                            }
-                            if lunch_val > config.max_duration_lunch_break {
-                                lunch_val = config.max_duration_lunch_break;
-                            }
-                            if lunch_val > 0 {
-                                tx.execute(
-                                    "UPDATE events SET lunch_break = ?1 WHERE id = ?2",
-                                    params![lunch_val, prev_out.id],
-                                )?;
-                                // also update legacy work_sessions lunch for compatibility
-                                let _ = upsert_lunch(&tx, date, lunch_val);
-                                // write an audit log entry inside the same transaction
-                                let msg = format!(
-                                    "auto_lunch {} min for out_event {} (date={})",
-                                    lunch_val, prev_out.id, date
-                                );
-                                tx.execute(
-                                    "INSERT INTO log (date, function, message) VALUES (?1, ?2, ?3)",
-                                    params![Utc::now().to_rfc3339(), "auto_lunch", msg],
-                                )?;
-                            }
+    if args.kind == "in"
+        && let Some(prev_out) = last_out_before(&tx, args.date, args.time)?
+    {
+        // Exclude holiday positions
+        if prev_out.position != "H" && position_to_use != "H" {
+            // Ensure previous out has no lunch yet
+            if prev_out.lunch_break == 0 {
+                // Parse times
+                if let (Ok(prev_time), Ok(new_time)) = (
+                    NaiveTime::parse_from_str(&prev_out.time, "%H:%M"),
+                    NaiveTime::parse_from_str(args.time, "%H:%M"),
+                ) {
+                    let noon = NaiveTime::from_hms_opt(12, 0, 0).unwrap();
+                    let latest = NaiveTime::from_hms_opt(14, 30, 0).unwrap();
+                    if prev_time >= noon && new_time <= latest && new_time > prev_time {
+                        let delta = (new_time - prev_time).num_minutes() as i32;
+                        let mut lunch_val = delta;
+                        if lunch_val < config.min_duration_lunch_break {
+                            lunch_val = config.min_duration_lunch_break;
+                        }
+                        if lunch_val > config.max_duration_lunch_break {
+                            lunch_val = config.max_duration_lunch_break;
+                        }
+                        if lunch_val > 0 {
+                            tx.execute(
+                                "UPDATE events SET lunch_break = ?1 WHERE id = ?2",
+                                params![lunch_val, prev_out.id],
+                            )?;
+                            // also update legacy work_sessions lunch for compatibility
+                            let _ = upsert_lunch(&tx, args.date, lunch_val);
+                            // write an audit log entry inside the same transaction
+                            let msg = format!(
+                                "auto_lunch {} min for out_event {} (date={})",
+                                lunch_val, prev_out.id, args.date
+                            );
+                            tx.execute(
+                                "INSERT INTO log (date, function, message) VALUES (?1, ?2, ?3)",
+                                params![Utc::now().to_rfc3339(), "auto_lunch", msg],
+                            )?;
                         }
                     }
                 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -206,3 +206,25 @@ pub fn get_session(conn: &Connection, id: i32) -> Result<Option<WorkSession>> {
         Err(e) => Err(e),
     }
 }
+
+/// Retrieve work sessions for a specific date
+pub fn list_sessions_by_date(conn: &Connection, date: &str) -> Result<Vec<WorkSession>> {
+    let query = "SELECT id, date, position, start_time, lunch_break, end_time FROM work_sessions WHERE date = ?1 ORDER BY date ASC";
+    let mut stmt = conn.prepare_cached(query)?;
+    let rows = stmt.query_map([date], |row| {
+        Ok(WorkSession {
+            id: row.get(0)?,
+            date: row.get(1)?,
+            position: row.get(2)?,
+            start: row.get(3)?,
+            lunch: row.get(4)?,
+            end: row.get(5)?,
+        })
+    })?;
+
+    let mut sessions = Vec::new();
+    for s in rows {
+        sessions.push(s?);
+    }
+    Ok(sessions)
+}

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,10 +1,11 @@
-use chrono::Utc;
-use rusqlite::{Connection, Result, ToSql, params};
+use chrono::{NaiveTime, Utc};
+use rusqlite::{Connection, OptionalExtension, Result, ToSql, params};
+use serde::Serialize;
 mod migrate;
 pub use migrate::run_pending_migrations;
 
 /// Represents a work session entry
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct WorkSession {
     pub id: i32,
     pub date: String,
@@ -12,6 +13,20 @@ pub struct WorkSession {
     pub start: String,
     pub lunch: i32,
     pub end: String,
+}
+
+/// Represents a single punch event (in/out)
+#[derive(Debug, Clone, Serialize)]
+pub struct Event {
+    pub id: i32,
+    pub date: String,
+    pub time: String,     // HH:MM
+    pub kind: String,     // "in" or "out"
+    pub position: String, // O,R,H,C
+    pub lunch_break: i32, // minutes, typically set on out
+    pub source: String,
+    pub meta: String,
+    pub created_at: String, // ISO timestamp
 }
 
 /// Initialize the database schema.
@@ -33,6 +48,18 @@ pub fn init_db(conn: &Connection) -> Result<()> {
             date TEXT NOT NULL,
             function TEXT NOT NULL,
             message TEXT NOT NULL
+        );
+
+        CREATE TABLE IF NOT EXISTS events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            date TEXT NOT NULL,          -- YYYY-MM-DD
+            time TEXT NOT NULL,          -- HH:MM
+            kind TEXT NOT NULL CHECK (kind IN ('in','out')),
+            position TEXT NOT NULL CHECK (position IN ('O','R','H','C')),
+            lunch_break INTEGER NOT NULL DEFAULT 0, -- minutes, typically set on out
+            source TEXT NOT NULL,
+            meta TEXT,
+            created_at TEXT NOT NULL     -- ISO 8601 timestamp
         );
         ",
     )?;
@@ -135,15 +162,22 @@ pub fn upsert_position(conn: &Connection, date: &str, pos: &str) -> Result<()> {
 
 /// Insert or update the start time (HH:MM) for a given date.
 pub fn upsert_start(conn: &Connection, date: &str, start: &str) -> Result<()> {
-    let mut stmt =
-        conn.prepare_cached("UPDATE work_sessions SET start_time = ?1 WHERE date = ?2")?;
+    // Update only if start_time is empty (preserve first start of the day)
+    let mut stmt = conn.prepare_cached(
+        "UPDATE work_sessions SET start_time = ?1 WHERE date = ?2 AND (start_time = '' OR start_time IS NULL)",
+    )?;
     let rows = stmt.execute(params![start, date])?;
     if rows == 0 {
-        let mut ins = conn.prepare_cached(
-            "INSERT INTO work_sessions (date, position, start_time, lunch_break, end_time)
-             VALUES (?1, 'A', ?2, 0, '')",
-        )?;
-        ins.execute(params![date, start])?;
+        // If no existing row was updated, ensure a row exists; if not, insert with provided start
+        let mut check = conn.prepare_cached("SELECT id FROM work_sessions WHERE date = ?1")?;
+        let exists = check.query_row([date], |_| Ok(() as ())).optional()?;
+        if exists.is_none() {
+            let mut ins = conn.prepare_cached(
+                "INSERT INTO work_sessions (date, position, start_time, lunch_break, end_time)
+                 VALUES (?1, 'A', ?2, 0, '')",
+            )?;
+            ins.execute(params![date, start])?;
+        }
     }
     Ok(())
 }
@@ -226,5 +260,305 @@ pub fn list_sessions_by_date(conn: &Connection, date: &str) -> Result<Vec<WorkSe
     for s in rows {
         sessions.push(s?);
     }
+    Ok(sessions)
+}
+
+/// List events for a specific date (ordered by time asc)
+pub fn list_events_by_date(conn: &Connection, date: &str) -> Result<Vec<Event>> {
+    let mut stmt = conn.prepare_cached(
+        "SELECT id, date, time, kind, position, lunch_break, source, meta, created_at FROM events WHERE date = ?1 ORDER BY time ASC",
+    )?;
+    let rows = stmt.query_map([date], |row| {
+        Ok(Event {
+            id: row.get(0)?,
+            date: row.get(1)?,
+            time: row.get(2)?,
+            kind: row.get(3)?,
+            position: row.get(4)?,
+            lunch_break: row.get(5)?,
+            source: row.get(6)?,
+            meta: row.get(7)?,
+            created_at: row.get(8)?,
+        })
+    })?;
+
+    let mut evs = Vec::new();
+    for e in rows {
+        evs.push(e?);
+    }
+    Ok(evs)
+}
+
+/// List all events in the database ordered by date and time
+pub fn list_events(conn: &Connection) -> Result<Vec<Event>> {
+    let mut stmt = conn.prepare_cached(
+        "SELECT id, date, time, kind, position, lunch_break, source, meta, created_at FROM events ORDER BY date ASC, time ASC",
+    )?;
+    let rows = stmt.query_map([], |row| {
+        Ok(Event {
+            id: row.get(0)?,
+            date: row.get(1)?,
+            time: row.get(2)?,
+            kind: row.get(3)?,
+            position: row.get(4)?,
+            lunch_break: row.get(5)?,
+            source: row.get(6)?,
+            meta: row.get(7)?,
+            created_at: row.get(8)?,
+        })
+    })?;
+
+    let mut evs = Vec::new();
+    for e in rows {
+        evs.push(e?);
+    }
+    Ok(evs)
+}
+
+/// List events filtered by optional period (YYYY or YYYY-MM) and position
+pub fn list_events_filtered(
+    conn: &Connection,
+    period: Option<&str>,
+    pos: Option<&str>,
+) -> Result<Vec<Event>> {
+    let mut query = String::from(
+        "SELECT id, date, time, kind, position, lunch_break, source, meta, created_at FROM events",
+    );
+    let mut conditions: Vec<String> = Vec::new();
+    let mut params: Vec<String> = Vec::new();
+
+    if let Some(p) = period {
+        if p.len() == 4 {
+            // year
+            conditions.push("strftime('%Y', date) = ?".to_string());
+            params.push(p.to_string());
+        } else if p.len() == 7 {
+            // year-month
+            conditions.push("strftime('%Y-%m', date) = ?".to_string());
+            params.push(p.to_string());
+        } else {
+            return Err(rusqlite::Error::InvalidQuery);
+        }
+    }
+    if let Some(pos_filter) = pos {
+        let up = pos_filter.trim().to_uppercase();
+        conditions.push("position = ?".to_string());
+        params.push(up);
+    }
+    if !conditions.is_empty() {
+        query.push_str(" WHERE ");
+        query.push_str(&conditions.join(" AND "));
+    }
+    query.push_str(" ORDER BY date ASC, time ASC");
+
+    let mut stmt = conn.prepare_cached(&query)?;
+    let param_refs: Vec<&dyn ToSql> = params.iter().map(|s| s as &dyn ToSql).collect();
+    let rows = stmt.query_map(param_refs.as_slice(), |row| {
+        Ok(Event {
+            id: row.get(0)?,
+            date: row.get(1)?,
+            time: row.get(2)?,
+            kind: row.get(3)?,
+            position: row.get(4)?,
+            lunch_break: row.get(5)?,
+            source: row.get(6)?,
+            meta: row.get(7)?,
+            created_at: row.get(8)?,
+        })
+    })?;
+    let mut evs = Vec::new();
+    for e in rows {
+        evs.push(e?);
+    }
+    Ok(evs)
+}
+
+/// Find last out event before a given time on the same date
+pub fn last_out_before(conn: &Connection, date: &str, time: &str) -> Result<Option<Event>> {
+    let mut stmt = conn.prepare_cached(
+        "SELECT id, date, time, kind, position, lunch_break, source, meta, created_at FROM events WHERE date = ?1 AND kind = 'out' AND time < ?2 ORDER BY time DESC LIMIT 1",
+    )?;
+    match stmt.query_row([date, time], |row| {
+        Ok(Event {
+            id: row.get(0)?,
+            date: row.get(1)?,
+            time: row.get(2)?,
+            kind: row.get(3)?,
+            position: row.get(4)?,
+            lunch_break: row.get(5)?,
+            source: row.get(6)?,
+            meta: row.get(7)?,
+            created_at: row.get(8)?,
+        })
+    }) {
+        Ok(ev) => Ok(Some(ev)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+/// Update lunch_break for a specific event (typically an 'out')
+pub fn set_event_lunch(conn: &Connection, event_id: i32, lunch: i32) -> Result<()> {
+    conn.execute(
+        "UPDATE events SET lunch_break = ?1 WHERE id = ?2",
+        params![lunch, event_id],
+    )?;
+    Ok(())
+}
+
+/// Insert an event and run auto-lunch logic if kind == 'in'.
+/// This function uses a transaction to ensure atomicity. It also performs dual-write
+/// to legacy `work_sessions` via existing upsert_* helpers to keep backwards compatibility.
+pub fn add_event(
+    conn: &mut Connection,
+    date: &str,
+    time: &str,
+    kind: &str,
+    position: Option<&str>,
+    source: &str,
+    meta: Option<&str>,
+    config: &crate::config::Config,
+) -> Result<i64> {
+    let tx = conn.transaction()?;
+
+    // Determine position_to_use:
+    // - if user provided position (Some) -> use it
+    // - else if kind == 'out' -> try to inherit from last 'in' on the same date
+    // - otherwise fallback to config.default_position
+    let mut position_to_use = if let Some(p) = position {
+        p.to_string()
+    } else {
+        config.default_position.clone()
+    };
+    if position.is_none() && kind == "out" {
+        let mut stmt = tx.prepare_cached(
+            "SELECT position FROM events WHERE date = ?1 AND kind = 'in' AND time <= ?2 ORDER BY time DESC LIMIT 1",
+        )?;
+        if let Some(found_pos) = stmt
+            .query_row([date, time], |row| row.get::<_, String>(0))
+            .optional()?
+        {
+            position_to_use = found_pos;
+        }
+    }
+
+    tx.execute(
+        "INSERT INTO events (date, time, kind, position, lunch_break, source, meta, created_at) VALUES (?1, ?2, ?3, ?4, 0, ?5, ?6, ?7)",
+        params![date, time, kind, position_to_use, source, meta.unwrap_or(""), Utc::now().to_rfc3339()],
+    )?;
+
+    let event_id = tx.last_insert_rowid();
+
+    // Dual-write to legacy table to ease rollout
+    if kind == "in" {
+        // store start in legacy place
+        let _ = upsert_start(&tx, date, time);
+    } else if kind == "out" {
+        let _ = upsert_end(&tx, date, time);
+    }
+
+    // If this is an 'in' event, attempt to populate lunch on the previous 'out' (auto-lunch)
+    if kind == "in" {
+        if let Some(prev_out) = last_out_before(&tx, date, time)? {
+            // Exclude holiday positions
+            if prev_out.position != "H" && position_to_use != "H" {
+                // Ensure previous out has no lunch yet
+                if prev_out.lunch_break == 0 {
+                    // Parse times
+                    if let (Ok(prev_time), Ok(new_time)) = (
+                        NaiveTime::parse_from_str(&prev_out.time, "%H:%M"),
+                        NaiveTime::parse_from_str(time, "%H:%M"),
+                    ) {
+                        let noon = NaiveTime::from_hms_opt(12, 0, 0).unwrap();
+                        let latest = NaiveTime::from_hms_opt(14, 30, 0).unwrap();
+                        if prev_time >= noon && new_time <= latest && new_time > prev_time {
+                            let delta = (new_time - prev_time).num_minutes() as i32;
+                            let mut lunch_val = delta;
+                            if lunch_val < config.min_duration_lunch_break {
+                                lunch_val = config.min_duration_lunch_break;
+                            }
+                            if lunch_val > config.max_duration_lunch_break {
+                                lunch_val = config.max_duration_lunch_break;
+                            }
+                            if lunch_val > 0 {
+                                tx.execute(
+                                    "UPDATE events SET lunch_break = ?1 WHERE id = ?2",
+                                    params![lunch_val, prev_out.id],
+                                )?;
+                                // also update legacy work_sessions lunch for compatibility
+                                let _ = upsert_lunch(&tx, date, lunch_val);
+                                // write an audit log entry inside the same transaction
+                                let msg = format!(
+                                    "auto_lunch {} min for out_event {} (date={})",
+                                    lunch_val, prev_out.id, date
+                                );
+                                tx.execute(
+                                    "INSERT INTO log (date, function, message) VALUES (?1, ?2, ?3)",
+                                    params![Utc::now().to_rfc3339(), "auto_lunch", msg],
+                                )?;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    tx.commit()?;
+    Ok(event_id)
+}
+
+/// Reconstruct work sessions from events for a given date.
+/// Produces one WorkSession per matched in/out pair (or partial if unmatched).
+pub fn reconstruct_sessions_from_events(conn: &Connection, date: &str) -> Result<Vec<WorkSession>> {
+    let events = list_events_by_date(conn, date)?;
+    let mut sessions: Vec<WorkSession> = Vec::new();
+
+    let mut pending_in: Option<Event> = None;
+
+    for e in events {
+        if e.kind == "in" {
+            // treat latest 'in' as the pending entry
+            pending_in = Some(e);
+        } else if e.kind == "out" {
+            if let Some(in_ev) = pending_in.take() {
+                // matched pair
+                let ws = WorkSession {
+                    id: e.id, // use out event id as session id
+                    date: date.to_string(),
+                    position: in_ev.position.clone(),
+                    start: in_ev.time.clone(),
+                    lunch: e.lunch_break,
+                    end: e.time.clone(),
+                };
+                sessions.push(ws);
+            } else {
+                // out without in -> partial session
+                let ws = WorkSession {
+                    id: e.id,
+                    date: date.to_string(),
+                    position: e.position.clone(),
+                    start: "".to_string(),
+                    lunch: e.lunch_break,
+                    end: e.time.clone(),
+                };
+                sessions.push(ws);
+            }
+        }
+    }
+
+    // any remaining pending_in -> incomplete session
+    if let Some(in_ev) = pending_in {
+        let ws = WorkSession {
+            id: in_ev.id,
+            date: date.to_string(),
+            position: in_ev.position.clone(),
+            start: in_ev.time.clone(),
+            lunch: 0,
+            end: "".to_string(),
+        };
+        sessions.push(ws);
+    }
+
     Ok(sessions)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,10 @@ enum Commands {
         /// Filter by position (O=Office, R=Remote, H=Holiday)
         #[arg(long)]
         pos: Option<String>,
+
+        /// Show only today's record (if present)
+        #[arg(long = "now", help = "Show only today's record")]
+        now: bool,
     },
 }
 
@@ -144,7 +148,7 @@ fn main() -> rusqlite::Result<()> {
             separator_char: "-".to_string(),
         }
     } else {
-        // For production we load the configuration from disk.
+        // For production, we load the configuration from disk.
         Config::load()
     };
 
@@ -169,8 +173,8 @@ fn main() -> rusqlite::Result<()> {
         Commands::Log { .. } => commands::handle_log(&cli.command, &conn),
         Commands::Add { .. } => commands::handle_add(&cli.command, &conn, &config),
         Commands::Del { .. } => commands::handle_del(&cli.command, &conn),
-        Commands::List { period, pos } => {
-            commands::handle_list(period.clone(), pos.clone(), &conn, &config)
+        Commands::List { period, pos, now } => {
+            commands::handle_list(period.clone(), pos.clone(), *now, &conn, &config)
         }
         _ => Ok(()),
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -942,11 +942,43 @@ fn test_events_unmatched_in_with_star_and_json() {
 #[test]
 fn test_events_summary_basic() {
     let db_path = setup_test_db("events_summary_basic");
-    Command::cargo_bin("rtimelog").unwrap().args(["--db", &db_path, "--test", "init"]).assert().success();
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "--test", "init"])
+        .assert()
+        .success();
     // Pair 1
-    Command::cargo_bin("rtimelog").unwrap().args(["--db", &db_path, "--test", "add", "2025-12-01", "O", "09:00", "30", "12:00"]).assert().success();
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "--test",
+            "add",
+            "2025-12-01",
+            "O",
+            "09:00",
+            "30",
+            "12:00",
+        ])
+        .assert()
+        .success();
     // Pair 2
-    Command::cargo_bin("rtimelog").unwrap().args(["--db", &db_path, "--test", "add", "2025-12-01", "O", "13:00", "30", "17:00"]).assert().success();
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "--test",
+            "add",
+            "2025-12-01",
+            "O",
+            "13:00",
+            "30",
+            "17:00",
+        ])
+        .assert()
+        .success();
 
     Command::cargo_bin("rtimelog")
         .unwrap()
@@ -963,15 +995,56 @@ fn test_events_summary_basic() {
 #[test]
 fn test_events_summary_filter_pair() {
     let db_path = setup_test_db("events_summary_filter_pair");
-    Command::cargo_bin("rtimelog").unwrap().args(["--db", &db_path, "--test", "init"]).assert().success();
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "--test", "init"])
+        .assert()
+        .success();
     // Pair 1
-    Command::cargo_bin("rtimelog").unwrap().args(["--db", &db_path, "--test", "add", "2025-12-02", "R", "08:30", "30", "11:30"]).assert().success();
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "--test",
+            "add",
+            "2025-12-02",
+            "R",
+            "08:30",
+            "30",
+            "11:30",
+        ])
+        .assert()
+        .success();
     // Pair 2
-    Command::cargo_bin("rtimelog").unwrap().args(["--db", &db_path, "--test", "add", "2025-12-02", "R", "12:30", "0", "16:00"]).assert().success();
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "--test",
+            "add",
+            "2025-12-02",
+            "R",
+            "12:30",
+            "0",
+            "16:00",
+        ])
+        .assert()
+        .success();
 
     Command::cargo_bin("rtimelog")
         .unwrap()
-        .args(["--db", &db_path, "--test", "list", "--events", "--summary", "--pairs", "2"])
+        .args([
+            "--db",
+            &db_path,
+            "--test",
+            "list",
+            "--events",
+            "--summary",
+            "--pairs",
+            "2",
+        ])
         .assert()
         .success()
         .stdout(contains("Event pairs summary"))
@@ -983,15 +1056,53 @@ fn test_events_summary_filter_pair() {
 #[test]
 fn test_events_summary_json() {
     let db_path = setup_test_db("events_summary_json");
-    Command::cargo_bin("rtimelog").unwrap().args(["--db", &db_path, "--test", "init"]).assert().success();
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "--test", "init"])
+        .assert()
+        .success();
     // Pair 1
-    Command::cargo_bin("rtimelog").unwrap().args(["--db", &db_path, "--test", "add", "2025-12-03", "O", "09:10", "30", "12:10"]).assert().success();
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "--test",
+            "add",
+            "2025-12-03",
+            "O",
+            "09:10",
+            "30",
+            "12:10",
+        ])
+        .assert()
+        .success();
     // Pair 2 unmatched (solo in)
-    Command::cargo_bin("rtimelog").unwrap().args(["--db", &db_path, "--test", "add", "2025-12-03", "O", "13:05"]).assert().success();
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "--test",
+            "add",
+            "2025-12-03",
+            "O",
+            "13:05",
+        ])
+        .assert()
+        .success();
 
     Command::cargo_bin("rtimelog")
         .unwrap()
-        .args(["--db", &db_path, "--test", "list", "--events", "--summary", "--json"])
+        .args([
+            "--db",
+            &db_path,
+            "--test",
+            "list",
+            "--events",
+            "--summary",
+            "--json",
+        ])
         .assert()
         .success()
         .stdout(contains("\"pair\""))
@@ -1003,9 +1114,25 @@ fn test_events_summary_json() {
 #[test]
 fn test_events_summary_unmatched_only() {
     let db_path = setup_test_db("events_summary_unmatched_only");
-    Command::cargo_bin("rtimelog").unwrap().args(["--db", &db_path, "--test", "init"]).assert().success();
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "--test", "init"])
+        .assert()
+        .success();
     // single IN event
-    Command::cargo_bin("rtimelog").unwrap().args(["--db", &db_path, "--test", "add", "2025-12-04", "R", "10:00"]).assert().success();
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "--test",
+            "add",
+            "2025-12-04",
+            "R",
+            "10:00",
+        ])
+        .assert()
+        .success();
 
     Command::cargo_bin("rtimelog")
         .unwrap()
@@ -1016,4 +1143,3 @@ fn test_events_summary_unmatched_only() {
         .stdout(contains("1*"))
         .stdout(contains("Dur"));
 }
-

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -672,3 +672,348 @@ fn test_separator_after_month_end() {
         .stdout(contains("2025-09-30"))
         .stdout(contains(sep25));
 }
+
+#[test]
+fn test_list_events_filter_position_case_insensitive() {
+    let db_path = setup_test_db("events_pos_case");
+
+    // Init DB
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "--test", "init"])
+        .assert()
+        .success();
+
+    // Add Remote (R) session which creates two events (in/out)
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "--test",
+            "add",
+            "2025-09-21",
+            "R",
+            "09:00",
+            "30",
+            "17:00",
+        ])
+        .assert()
+        .success();
+
+    // Add Office (O) session
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "--test",
+            "add",
+            "2025-09-22",
+            "O",
+            "09:10",
+            "30",
+            "17:10",
+        ])
+        .assert()
+        .success();
+
+    // List events filtering with lowercase 'r' to verify case-insensitive normalization
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "--test", "list", "--events", "--pos", "r"])
+        .assert()
+        .success()
+        .stdout(contains("2025-09-21")) // remote date present
+        .stdout(contains("2025-09-22").not()); // office date absent
+}
+
+#[test]
+fn test_events_pair_column_and_grouping() {
+    let db_path = setup_test_db("events_pair_col");
+
+    // Init DB
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "--test", "init"])
+        .assert()
+        .success();
+
+    // Prima sessione (in/out)
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "--test",
+            "add",
+            "2025-10-02",
+            "R",
+            "09:00",
+            "30",
+            "12:00",
+        ])
+        .assert()
+        .success();
+
+    // Seconda sessione (in/out)
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "--test",
+            "add",
+            "2025-10-02",
+            "R",
+            "13:00",
+            "0",
+            "17:00",
+        ])
+        .assert()
+        .success();
+
+    // Lista eventi e verifica intestazione Pair e presenza dei pair id 1 e 2
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "--test", "list", "--events", "--pos", "R"])
+        .assert()
+        .success()
+        .stdout(contains("Pair"))
+        .stdout(contains("  1"))
+        .stdout(contains("  2"));
+}
+
+#[test]
+fn test_events_filter_by_single_pair() {
+    let db_path = setup_test_db("events_filter_pair");
+
+    // Init
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "--test", "init"])
+        .assert()
+        .success();
+
+    // Pair 1
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "--test",
+            "add",
+            "2025-11-01",
+            "O",
+            "09:00",
+            "30",
+            "12:00",
+        ])
+        .assert()
+        .success();
+    // Pair 2
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "--test",
+            "add",
+            "2025-11-01",
+            "O",
+            "13:00",
+            "30",
+            "17:00",
+        ])
+        .assert()
+        .success();
+
+    // Filtro --pairs 1 deve mostrare solo gli eventi del primo intervallo
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db", &db_path, "--test", "list", "--events", "--pairs", "1",
+        ])
+        .assert()
+        .success()
+        .stdout(contains("09:00"))
+        .stdout(contains("12:00"))
+        .stdout(contains("13:00").not())
+        .stdout(contains("17:00").not())
+        .stdout(contains("  1").or(contains("  1*"))); // pair id
+}
+
+#[test]
+fn test_events_json_enriched_with_pairs() {
+    let db_path = setup_test_db("events_json_pairs");
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "--test", "init"])
+        .assert()
+        .success();
+
+    // Due coppie
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "--test",
+            "add",
+            "2025-11-02",
+            "R",
+            "08:30",
+            "30",
+            "12:00",
+        ])
+        .assert()
+        .success();
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "--test",
+            "add",
+            "2025-11-02",
+            "R",
+            "13:00",
+            "0",
+            "16:30",
+        ])
+        .assert()
+        .success();
+
+    // JSON
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "--test", "list", "--events", "--json"])
+        .assert()
+        .success()
+        .stdout(contains("\"pair\""))
+        .stdout(contains("\"unmatched\""))
+        .stdout(contains("08:30"))
+        .stdout(contains("16:30"));
+}
+
+#[test]
+fn test_events_unmatched_in_with_star_and_json() {
+    let db_path = setup_test_db("events_unmatched_in");
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "--test", "init"])
+        .assert()
+        .success();
+
+    // Solo evento in (start senza end)
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "--test",
+            "add",
+            "2025-11-03",
+            "O",
+            "09:05",
+        ])
+        .assert()
+        .success();
+
+    // Output tabellare: deve contenere '1*' nella colonna Pair (pair id 1 unmatched)
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "--test", "list", "--events"])
+        .assert()
+        .success()
+        .stdout(contains("09:05"))
+        .stdout(contains("1*"));
+
+    // Output JSON: pair=1 e unmatched=true
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "--test", "list", "--events", "--json"])
+        .assert()
+        .success()
+        .stdout(contains("\"pair\": 1"))
+        .stdout(contains("\"unmatched\": true"));
+}
+
+#[test]
+fn test_events_summary_basic() {
+    let db_path = setup_test_db("events_summary_basic");
+    Command::cargo_bin("rtimelog").unwrap().args(["--db", &db_path, "--test", "init"]).assert().success();
+    // Pair 1
+    Command::cargo_bin("rtimelog").unwrap().args(["--db", &db_path, "--test", "add", "2025-12-01", "O", "09:00", "30", "12:00"]).assert().success();
+    // Pair 2
+    Command::cargo_bin("rtimelog").unwrap().args(["--db", &db_path, "--test", "add", "2025-12-01", "O", "13:00", "30", "17:00"]).assert().success();
+
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "--test", "list", "--events", "--summary"])
+        .assert()
+        .success()
+        .stdout(contains("Event pairs summary"))
+        .stdout(contains("2025-12-01"))
+        .stdout(contains("1"))
+        .stdout(contains("2"))
+        .stdout(contains("Dur"));
+}
+
+#[test]
+fn test_events_summary_filter_pair() {
+    let db_path = setup_test_db("events_summary_filter_pair");
+    Command::cargo_bin("rtimelog").unwrap().args(["--db", &db_path, "--test", "init"]).assert().success();
+    // Pair 1
+    Command::cargo_bin("rtimelog").unwrap().args(["--db", &db_path, "--test", "add", "2025-12-02", "R", "08:30", "30", "11:30"]).assert().success();
+    // Pair 2
+    Command::cargo_bin("rtimelog").unwrap().args(["--db", &db_path, "--test", "add", "2025-12-02", "R", "12:30", "0", "16:00"]).assert().success();
+
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "--test", "list", "--events", "--summary", "--pairs", "2"])
+        .assert()
+        .success()
+        .stdout(contains("Event pairs summary"))
+        .stdout(contains("12:30"))
+        .stdout(contains("16:00"))
+        .stdout(contains("08:30").not());
+}
+
+#[test]
+fn test_events_summary_json() {
+    let db_path = setup_test_db("events_summary_json");
+    Command::cargo_bin("rtimelog").unwrap().args(["--db", &db_path, "--test", "init"]).assert().success();
+    // Pair 1
+    Command::cargo_bin("rtimelog").unwrap().args(["--db", &db_path, "--test", "add", "2025-12-03", "O", "09:10", "30", "12:10"]).assert().success();
+    // Pair 2 unmatched (solo in)
+    Command::cargo_bin("rtimelog").unwrap().args(["--db", &db_path, "--test", "add", "2025-12-03", "O", "13:05"]).assert().success();
+
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "--test", "list", "--events", "--summary", "--json"])
+        .assert()
+        .success()
+        .stdout(contains("\"pair\""))
+        .stdout(contains("\"duration_minutes\""))
+        .stdout(contains("\"unmatched\": true"))
+        .stdout(contains("09:10"));
+}
+
+#[test]
+fn test_events_summary_unmatched_only() {
+    let db_path = setup_test_db("events_summary_unmatched_only");
+    Command::cargo_bin("rtimelog").unwrap().args(["--db", &db_path, "--test", "init"]).assert().success();
+    // single IN event
+    Command::cargo_bin("rtimelog").unwrap().args(["--db", &db_path, "--test", "add", "2025-12-04", "R", "10:00"]).assert().success();
+
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "--test", "list", "--events", "--summary"])
+        .assert()
+        .success()
+        .stdout(contains("10:00"))
+        .stdout(contains("1*"))
+        .stdout(contains("Dur"));
+}
+


### PR DESCRIPTION
# [0.4.0] - 2025-10-02

### Added

- Event pair aggregation features:
  - Derived **Pair** column when listing events (sequential pairing of `in` with next `out` per date, FIFO).
  - `--pairs <id>` filter to show only events (or summaries) for a specific pair id.
  - `--summary` mode (only with `--events`) to display one aggregated row per pair (start, end, lunch, net duration, unmatched flag).
  - Enriched JSON output (`--events --json` and `--events --summary --json`) including fields: `pair`, `unmatched`, `lunch_minutes`, `duration_minutes` (summary mode).
- Unmatched event handling: lone `in` or `out` events are marked with an asterisk (`*`) after the pair id and `"unmatched": true` in JSON.
- Case‑insensitive normalization for `--pos` filter when listing events/sessions (`r` / `R` behave the same).
- Automatic dual-write: `add --in/--out` now (still) logs legacy session data and inserts punch events used by the new reporting features.
- New integration tests covering:
  - Pair calculation and filtering
  - Summary (basic, filtered, JSON, unmatched)
  - Enriched JSON schema
  - Case-insensitive position filter for events

### Changed

- Refactored event printing logic into helper functions (`compute_event_pairs`, `compute_event_summaries`, summary/table printers).
- Improved output alignment for event and summary tables.
- Internal minor cleanups (pattern matching adjustments for 2024 edition, separator printing, warning removal).

### Fixed

- Proper representation of unmatched events; they no longer appear merged with unrelated pairs.
- Prevented spurious formatting warnings in summary table output.

### Notes

- No breaking schema changes: all new capabilities are additive and backward‑compatible with existing databases.
- Legacy session listing (`list`) remains unchanged; new functionality is activated only with `--events`.
