### PR TITLE
V0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+# [0.4.1] - 2025-10-03
+
+### Added
+
+- Unit test(s) targeting the creation of missing events (exposed for unit testing).
+
+### Changed
+
+- Refactored event helper logic:
+  - Extracted `create_missing_event` helper into a reusable function and moved it to `src/events.rs` for better testability and separation of concerns.
+  - Removed duplicated code in `commands.rs` and consolidated the helper usage.
+- Presentation improvement: in `list --events --summary` the Duration field is now displayed in a human-friendly "Xh Ym" format instead of raw minutes (display-only change).
+- Updated integration tests to cover the new event creation logic.
+
+### Fixed
+
+- Resolved compilation issues caused by duplicate definitions in `commands.rs`.
+
+---
+
 # [0.4.0] - 2025-10-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "r_timelog"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r_timelog"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 authors = ["Umpire274 <umpire274@gmail.com>"]
 description = "A simple cross-platform CLI tool to track working hours, lunch breaks, and calculate surplus time"

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,0 +1,5 @@
+Refactor(events): move create_missing_event to new module and add test 
+ 
+- Moved create_missing_event into src/events.rs and exported it for testability. 
+- Updated src/commands.rs to call _timelog::events::create_missing_event. 
+- Added integration test 	ests/missing_event_tests.rs. 

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,7 +1,0 @@
-Fix: resolve compilation errors and deduplicate event-creation logic in src/commands.rs 
- 
-- Fixed mismatched delimiters and invalid patterns in handle_add that caused parsing/compiler errors. 
-- Removed lifetime-unsafe closure and construct AddEventArgs inline to avoid temporary borrows. 
-- Consolidated duplicate 'create missing event' logic into a single local helper to reduce duplication. 
-- Adjusted validations and conditions for robust time parsing and updates. 
-- Ran cargo build and full test suite locally; all tests passed. 

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,5 +1,0 @@
-Refactor(events): move create_missing_event to new module and add test 
- 
-- Moved create_missing_event into src/events.rs and exported it for testability. 
-- Updated src/commands.rs to call _timelog::events::create_missing_event. 
-- Added integration test 	ests/missing_event_tests.rs. 

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,0 +1,6 @@
+Refactor: extract create_missing_event helper and add missing-event test 
+ 
+- Extracted shared function create_missing_event from handle_add to improve reuse and readability. 
+- Replaced local closure with call to the new private helper. 
+- Added integration test 	ests/missing_event_tests.rs verifying creating missing 'in' when only 'out' exists. 
+- Ran cargo test locally and ensured all tests pass. 

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,6 +1,0 @@
-Refactor: extract create_missing_event helper and add missing-event test 
- 
-- Extracted shared function create_missing_event from handle_add to improve reuse and readability. 
-- Replaced local closure with call to the new private helper. 
-- Added integration test 	ests/missing_event_tests.rs verifying creating missing 'in' when only 'out' exists. 
-- Ran cargo test locally and ensured all tests pass. 

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,0 +1,7 @@
+Fix: resolve compilation errors and deduplicate event-creation logic in src/commands.rs 
+ 
+- Fixed mismatched delimiters and invalid patterns in handle_add that caused parsing/compiler errors. 
+- Removed lifetime-unsafe closure and construct AddEventArgs inline to avoid temporary borrows. 
+- Consolidated duplicate 'create missing event' logic into a single local helper to reduce duplication. 
+- Adjusted validations and conditions for robust time parsing and updates. 
+- Ran cargo build and full test suite locally; all tests passed. 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1128,6 +1128,8 @@ fn print_events_summary(rows: &[SummaryRow], title: &str) {
     let mut w_start = 5usize;
     let mut w_end = 5usize;
     let mut w_lunch = 5usize;
+    // We'll display duration as "XH YYM" (e.g. "8H 00M") so compute formatted strings first
+    let mut formatted_dur: Vec<String> = Vec::with_capacity(rows.len());
     let mut w_dur = 3usize;
     for r in rows {
         w_date = w_date.max(r.date.len());
@@ -1136,7 +1138,13 @@ fn print_events_summary(rows: &[SummaryRow], title: &str) {
         w_start = w_start.max(r.start.len());
         w_end = w_end.max(r.end.len());
         w_lunch = w_lunch.max(r.lunch_minutes.to_string().len());
-        w_dur = w_dur.max(r.duration_minutes.to_string().len());
+        // prepare formatted duration
+        let mins = r.duration_minutes.max(0);
+        let hh = mins / 60;
+        let mm = mins % 60;
+        let dur_str = format!("{}H {:02}M", hh, mm);
+        w_dur = w_dur.max(dur_str.len());
+        formatted_dur.push(dur_str);
     }
     println!(
         "{:<date$}  {:>pair$}  {:<pos$}  {:>start$}  {:>end$}  {:>lunch$}  {:>dur$}",
@@ -1165,8 +1173,9 @@ fn print_events_summary(rows: &[SummaryRow], title: &str) {
         "-".repeat(w_lunch),
         "-".repeat(w_dur),
     );
-    for r in rows {
+    for (i, r) in rows.iter().enumerate() {
         let pair_disp = format!("{}{}", r.pair, if r.unmatched { "*" } else { "" });
+        let dur_display = &formatted_dur[i];
         println!(
             "{:<date$}  {:>pair$}  {:<pos$}  {:>start$}  {:>end$}  {:>lunch$}  {:>dur$}",
             r.date,
@@ -1175,7 +1184,7 @@ fn print_events_summary(rows: &[SummaryRow], title: &str) {
             r.start,
             r.end,
             r.lunch_minutes,
-            r.duration_minutes,
+            dur_display,
             date = w_date,
             pair = w_pair,
             pos = w_pos,

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -149,11 +149,16 @@ pub fn handle_add(cmd: &Commands, conn: &mut Connection, config: &Config) -> rus
         start,
         lunch,
         end,
+        edit_pair,
+        edit,
     } = cmd
     {
         // validate date
         if chrono::NaiveDate::parse_from_str(date, "%Y-%m-%d").is_err() {
-            eprintln!("❌ Invalid date format: {} (expected YYYY-MM-DD)", date);
+            eprintln!(
+                "\u{274c} Invalid date format: {} (expected YYYY-MM-DD)",
+                date
+            );
             return Ok(());
         }
 
@@ -163,48 +168,220 @@ pub fn handle_add(cmd: &Commands, conn: &mut Connection, config: &Config) -> rus
         let lunch = (*lunch).or(*lunch_pos);
         let end = end.clone().or(end_pos.clone());
 
-        // Collect changes to log a single message at the end
-        let mut changes: Vec<String> = Vec::new();
+        // --------------------------------------------------
+        // EDIT MODE (explicit only)
+        // --------------------------------------------------
+        if *edit {
+            let pair_id = match edit_pair {
+                Some(p) => *p,
+                None => {
+                    eprintln!("\u{26a0}\u{FE0F} Missing --pair <id> with --edit");
+                    return Ok(());
+                }
+            };
 
-        // Handle position
-        if let Some(p) = pos.as_ref() {
-            let p = p.trim().to_uppercase();
-            if p != "O" && p != "R" && p != "H" && p != "C" {
+            let events = db::list_events_by_date(conn, date)?;
+            if events.is_empty() {
+                eprintln!("\u{26a0}\u{FE0F} No events for date {} to edit", date);
+                return Ok(());
+            }
+
+            let enriched = compute_event_pairs(&events);
+            let mut in_event: Option<db::Event> = None;
+            let mut out_event: Option<db::Event> = None;
+            for ew in enriched.iter().filter(|e| e.pair == pair_id) {
+                if ew.event.kind == "in" {
+                    in_event = Some(ew.event.clone());
+                } else if ew.event.kind == "out" {
+                    out_event = Some(ew.event.clone());
+                }
+            }
+
+            if in_event.is_none() && out_event.is_none() {
                 eprintln!(
-                    "❌ Invalid position: {} (use O=office or R=remote or H=Holiday or C=On-Site)",
-                    p
+                    "\u{26a0}\u{FE0F} Pair {} not found for date {}",
+                    pair_id, date
                 );
                 return Ok(());
             }
-            db::upsert_position(conn, date, &p)?;
-            let (pos_string, _) = describe_position(&p);
-            println!("✅ Position {} set for {}", pos_string, date);
-            changes.push(format!("position={}", p));
+
+            // Validazioni base tempi (collapse ifs)
+            if let Some(s) = start.as_ref()
+                && NaiveTime::parse_from_str(s, "%H:%M").is_err()
+            {
+                eprintln!("\u{274c} Invalid start time: {}", s);
+                return Ok(());
+            }
+            if let Some(e_t) = end.as_ref()
+                && NaiveTime::parse_from_str(e_t, "%H:%M").is_err()
+            {
+                eprintln!("\u{274c} Invalid end time: {}", e_t);
+                return Ok(());
+            }
+            if let (Some(s), Some(e_t)) = (start.as_ref(), end.as_ref())
+                && let (Ok(ts), Ok(te)) = (
+                    NaiveTime::parse_from_str(s, "%H:%M"),
+                    NaiveTime::parse_from_str(e_t, "%H:%M"),
+                )
+                && te <= ts
+            {
+                eprintln!(
+                    "\u{274c} End time must be after start time ({} >= {})",
+                    e_t, s
+                );
+                return Ok(());
+            }
+
+            // Creazione eventi mancanti se l'utente prova a completare la coppia
+            // Helper locale: crea un evento (in/out) se mancante e restituisce l'event creato se presente
+            let mut create_missing_event = |time_val: &str,
+                                            kind_val: &str,
+                                            prefer_other: Option<&db::Event>|
+             -> rusqlite::Result<Option<db::Event>> {
+                // Determina posizione preferita: flag pos (CLI) ha priorità, poi la posizione dell'altro evento (se presente), poi fallback config
+                let p_norm = pos.clone().unwrap_or_else(|| {
+                    prefer_other
+                        .map(|e| e.position.clone())
+                        .unwrap_or_else(|| config.default_position.clone())
+                });
+                let args = db::AddEventArgs {
+                    date,
+                    time: time_val,
+                    kind: kind_val,
+                    position: Some(p_norm.as_str()),
+                    source: "cli",
+                    meta: None,
+                };
+                if let Err(e) = db::add_event(conn, &args, config) {
+                    eprintln!(
+                        "\u{26a0}\u{FE0F} Failed to create missing {} event: {}",
+                        kind_val, e
+                    );
+                }
+                let found = db::list_events_by_date(conn, date)?
+                    .into_iter()
+                    .find(|ev| ev.kind == kind_val && ev.time == time_val);
+                Ok(found)
+            };
+
+            // Se l'utente fornisce un start ma manca l'evento 'in', lo creiamo qui
+            if let Some(sv) = start.as_ref()
+                && in_event.is_none()
+            {
+                in_event = create_missing_event(sv.as_str(), "in", out_event.as_ref())?;
+            }
+
+            // Se l'utente fornisce un end ma manca l'evento 'out', lo creiamo qui
+            if let Some(ev_t) = end.as_ref()
+                && out_event.is_none()
+            {
+                out_event = create_missing_event(ev_t.as_str(), "out", in_event.as_ref())?;
+            }
+
+            // Applica modifiche sugli eventi esistenti
+            let mut changes: Vec<String> = Vec::new();
+
+            if let Some(p) = pos.as_ref() {
+                let p_norm = p.trim().to_uppercase();
+                if p_norm != "O" && p_norm != "R" && p_norm != "H" && p_norm != "C" {
+                    eprintln!("\u{274c} Invalid position: {}", p_norm);
+                    return Ok(());
+                }
+                if let Some(ie) = in_event.as_ref() {
+                    let _ = db::set_event_position(conn, ie.id, &p_norm);
+                }
+                if let Some(oe) = out_event.as_ref() {
+                    let _ = db::set_event_position(conn, oe.id, &p_norm);
+                }
+                let _ = db::force_set_position(conn, date, &p_norm);
+                println!(
+                    "\u{2705} Position {} set for {} (pair {})",
+                    p_norm, date, pair_id
+                );
+                changes.push(format!("pos={}", p_norm));
+            }
+
+            if let (Some(sv), Some(ie)) = (start.as_ref(), in_event.as_ref()) {
+                let _ = db::set_event_time(conn, ie.id, sv.as_str());
+                let _ = db::force_set_start(conn, date, sv.as_str());
+                println!("\u{2705} Start {} updated (pair {})", sv, pair_id);
+                changes.push(format!("start={}", sv));
+            }
+
+            if let (Some(ev_t), Some(oe)) = (end.as_ref(), out_event.as_ref()) {
+                let _ = db::set_event_time(conn, oe.id, ev_t.as_str());
+                let _ = db::force_set_end(conn, date, ev_t.as_str());
+                println!("\u{2705} End {} updated (pair {})", ev_t, pair_id);
+                changes.push(format!("end={}", ev_t));
+            }
+
+            if let Some(lv) = lunch {
+                if !(0..=90).contains(&lv) {
+                    eprintln!("\u{274c} Invalid lunch break: {}", lv);
+                    return Ok(());
+                }
+                if let Some(oe) = out_event.as_ref() {
+                    let _ = db::set_event_lunch(conn, oe.id, lv);
+                    let _ = db::force_set_lunch(conn, date, lv);
+                    println!("\u{2705} Lunch {} min updated (pair {})", lv, pair_id);
+                    changes.push(format!("lunch={}", lv));
+                }
+            }
+
+            if changes.is_empty() {
+                eprintln!(
+                    "\u{26a0}\u{FE0F} No fields provided to edit (use --pos/--in/--out/--lunch)"
+                );
+            } else if let Err(e) = db::ttlog(
+                conn,
+                "edit",
+                &format!("date={} pair={} | {}", date, pair_id, changes.join(", ")),
+            ) {
+                eprintln!("\u{26a0}\u{FE0F} Failed to log edit: {}", e);
+            }
+
+            return Ok(());
+        }
+
+        // --------------------------------------------------
+        // NORMAL MODE (always create / upsert fields, never implicit edit of existing pair)
+        // --------------------------------------------------
+
+        // Handle position
+        if let Some(p) = pos.as_ref() {
+            let ptrim = p.trim().to_uppercase();
+            if ptrim != "O" && ptrim != "R" && ptrim != "H" && ptrim != "C" {
+                eprintln!(
+                    "\u{274c} Invalid position: {} (use O=office or R=remote or H=Holiday or C=On-Site)",
+                    ptrim
+                );
+                return Ok(());
+            }
+            let _ = db::upsert_position(conn, date, &ptrim);
+            let (pos_string, _) = describe_position(&ptrim);
+            println!("\u{2705} Position {} set for {}", pos_string, date);
         }
 
         // Handle start time
-        if let Some(s) = start.as_ref() {
-            if NaiveTime::parse_from_str(s, "%H:%M").is_err() {
-                eprintln!("❌ Invalid start time: {} (expected HH:MM)", s);
+        if let Some(sv) = start.as_ref() {
+            if NaiveTime::parse_from_str(sv, "%H:%M").is_err() {
+                eprintln!("\u{274c} Invalid start time: {} (expected HH:MM)", sv);
                 return Ok(());
             }
-            db::upsert_start(conn, date, s)?;
-            println!("✅ Start time {} registered for {}", s, date);
-            changes.push(format!("start={}", s));
-
-            // Dual-write: also record an event (in). Pass explicit position only if provided, normalized to uppercase.
+            db::upsert_start(conn, date, sv.as_str())?;
+            println!("\u{2705} Start time {} registered for {}", sv, date);
+            // event in
             let event_pos_owned: Option<String> = pos.as_ref().map(|p| p.trim().to_uppercase());
-            let event_pos_ref: Option<&str> = event_pos_owned.as_deref();
             let args = db::AddEventArgs {
                 date,
-                time: s,
+                time: sv.as_str(),
                 kind: "in",
-                position: event_pos_ref,
+                position: event_pos_owned.as_deref(),
                 source: "cli",
                 meta: None,
             };
             if let Err(e) = db::add_event(conn, &args, config) {
-                eprintln!("⚠️ Failed to insert event (in): {}", e);
+                eprintln!("\u{26a0}\u{FE0F} Failed to insert event (in): {}", e);
             }
         }
 
@@ -212,94 +389,72 @@ pub fn handle_add(cmd: &Commands, conn: &mut Connection, config: &Config) -> rus
         if let Some(l) = lunch {
             if !(0..=90).contains(&l) {
                 eprintln!(
-                    "❌ Invalid lunch break: {} (must be between 0 and 90 minutes)",
+                    "\u{274c} Invalid lunch break: {} (must be between 0 and 90 minutes)",
                     l
                 );
                 return Ok(());
             }
             db::upsert_lunch(conn, date, l)?;
-            println!("✅ Lunch {} min registered for {}", l, date);
-            changes.push(format!("lunch={}", l));
-
+            println!("\u{2705} Lunch {} min registered for {}", l, date);
             // Also, if there is an out event present, set its lunch_break for compatibility
             match db::last_out_before(conn, date, "23:59") {
                 Ok(Some(out_ev)) => {
                     if out_ev.lunch_break == 0
                         && let Err(e) = db::set_event_lunch(conn, out_ev.id, l)
                     {
-                        eprintln!("⚠️ Failed to set lunch on event {}: {}", out_ev.id, e);
+                        eprintln!(
+                            "\u{26a0}\u{FE0F} Failed to set lunch on event {}: {}",
+                            out_ev.id, e
+                        );
                     }
                 }
-                Ok(None) => {
-                    // no out events; nothing to update
-                }
-                Err(e) => eprintln!("⚠️ Error while searching for last out event: {}", e),
+                Ok(None) => {}
+                Err(e) => eprintln!(
+                    "\u{26a0}\u{FE0F} Error while searching for last out event: {}",
+                    e
+                ),
             }
         }
 
         // Handle end time
-        if let Some(e) = end.as_ref() {
-            if NaiveTime::parse_from_str(e, "%H:%M").is_err() {
-                eprintln!("❌ Invalid end time: {} (expected HH:MM)", e);
+        if let Some(ev_t) = end.as_ref() {
+            if NaiveTime::parse_from_str(ev_t, "%H:%M").is_err() {
+                eprintln!("\u{274c} Invalid end time: {} (expected HH:MM)", ev_t);
                 return Ok(());
             }
-            db::upsert_end(conn, date, e)?;
-            println!("✅ End time {} registered for {}", e, date);
-            changes.push(format!("end={}", e));
-
-            // Dual-write: also record an event (out). Pass explicit position only if provided.
+            db::upsert_end(conn, date, ev_t.as_str())?;
+            println!("\u{2705} End time {} registered for {}", ev_t, date);
             let event_pos_owned: Option<String> = pos.as_ref().map(|p| p.trim().to_uppercase());
-            let event_pos_ref: Option<&str> = event_pos_owned.as_deref();
             let args = db::AddEventArgs {
                 date,
-                time: e,
+                time: ev_t.as_str(),
                 kind: "out",
-                position: event_pos_ref,
+                position: event_pos_owned.as_deref(),
                 source: "cli",
                 meta: None,
             };
             if let Err(err) = db::add_event(conn, &args, config) {
-                eprintln!("⚠️ Failed to insert event (out): {}", err);
+                eprintln!("\u{26a0}\u{FE0F} Failed to insert event (out): {}", err);
             }
         }
 
-        // Warn if no field provided
         if pos.is_none() && start.is_none() && lunch.is_none() && end.is_none() {
-            eprintln!("⚠️ Please provide at least one of: position, start, lunch, end");
+            eprintln!(
+                "\u{26a0}\u{FE0F} Please provide at least one of: position, start, lunch, end (or use --edit --pair)"
+            );
         }
 
-        // Log the add operation if we recorded changes
-        if !changes.is_empty() {
-            let msg = format!("date={} | {}", date, changes.join(", "));
-            if let Err(e) = db::ttlog(conn, "add", &msg) {
-                eprintln!("⚠️ Failed to write internal log: {}", e);
-            }
-        }
-
-        // Recupera l'id dell'ultima sessione per la data fornita e invoca la stampa dettagliata
+        // Recupera l'id dell'ultima sessione per la data fornita e stampa
         match conn.prepare("SELECT id FROM work_sessions WHERE date = ?1 ORDER BY id DESC LIMIT 1")
         {
             Ok(mut stmt) => match stmt.query_row([date], |row| row.get::<_, i32>(0)) {
                 Ok(last_id) => {
-                    // Use the provided connection and config to print the updated record
                     let _ = handle_list_with_highlight(None, None, conn, config, Some(last_id));
                 }
-                Err(rusqlite::Error::QueryReturnedNoRows) => {
-                    // nessuna sessione da stampare
-                }
-                Err(e) => {
-                    eprintln!(
-                        "❌ Errore durante il recupero dell'id della sessione: {}",
-                        e
-                    );
-                }
+                Err(rusqlite::Error::QueryReturnedNoRows) => {}
+                Err(e) => eprintln!("\u{274c} Error retrieving session id: {}", e),
             },
-            Err(e) => {
-                eprintln!(
-                    "❌ Impossibile preparare la query per recuperare l'id: {}",
-                    e
-                );
-            }
+            Err(e) => eprintln!("\u{274c} Failed to prepare query for session id: {}", e),
         }
     }
 
@@ -818,7 +973,7 @@ struct EventWithPair {
     unmatched: bool,
 }
 
-/// Calcola per una slice di Event i pair id (sequenza per data) ed il flag unmatched.
+/// Calcola per una slice di Event i pair id (sequenza per data) e il flag unmatched.
 /// Regole:
 ///  - Ogni evento 'in' apre una nuova coppia con pair id incrementale (per data) e unmatched=true
 ///  - Il primo 'out' successivo chiude la prima coppia aperta (FIFO) e diventa stesso pair, unmatched=false (anche per l'in)
@@ -1151,7 +1306,7 @@ fn print_events_table_with_pairs(
     }
 }
 
-// Mantiene per retrocompatibilità la vecchia funzione ma delega alla nuova con enrich
+// Mantiene per retro compatibilità la vecchia funzione ma delega alla nuova con enrich
 fn print_events_table(events: &[db::Event], title: &str) {
     let enriched = compute_event_pairs(events);
     let plain: Vec<db::Event> = enriched.iter().map(|e| e.event.clone()).collect();

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,0 +1,40 @@
+use crate::config::Config;
+use crate::db;
+use rusqlite::Connection;
+
+/// Create a missing event (in/out) and return the created event if found.
+/// This is intentionally public to make it testable from unit/integration tests.
+pub fn create_missing_event(
+    conn: &mut Connection,
+    date: &str,
+    time_val: &str,
+    kind_val: &str,
+    pos_opt: &Option<String>,
+    prefer_other: Option<&db::Event>,
+    config: &Config,
+) -> rusqlite::Result<Option<db::Event>> {
+    // Determine preferred position: explicit CLI pos has priority, then other event's position, then config default
+    let p_norm = pos_opt.clone().unwrap_or_else(|| {
+        prefer_other
+            .map(|e| e.position.clone())
+            .unwrap_or_else(|| config.default_position.clone())
+    });
+
+    let args = db::AddEventArgs {
+        date,
+        time: time_val,
+        kind: kind_val,
+        position: Some(p_norm.as_str()),
+        source: "cli",
+        meta: None,
+    };
+
+    if let Err(e) = db::add_event(conn, &args, config) {
+        eprintln!("⚠️  Failed to create missing {} event: {}", kind_val, e);
+    }
+
+    let found = db::list_events_by_date(conn, date)?
+        .into_iter()
+        .find(|ev| ev.kind == kind_val && ev.time == time_val);
+    Ok(found)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
 pub mod db;
+pub mod events;
 pub mod logic;
 pub mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,6 +86,12 @@ enum Commands {
         /// (Option) End time (HH:MM)
         #[arg(long = "out")]
         end: Option<String>,
+        /// (Option) Pair id to edit (requires --edit)
+        #[arg(long = "pair", help = "Pair id to edit (with --edit)")]
+        edit_pair: Option<usize>,
+        /// Enable edit mode (together with --pair) to update an existing pair's events instead of creating new ones
+        #[arg(long = "edit", help = "Edit existing pair (use with --pair)")]
+        edit: bool,
     },
     /// Delete a work session by ID
     Del {

--- a/tests/missing_event_tests.rs
+++ b/tests/missing_event_tests.rs
@@ -1,0 +1,85 @@
+use assert_cmd::Command;
+use serde_json::Value;
+use std::env;
+use std::path::PathBuf;
+
+/// Create a unique test DB path inside the system temp dir
+fn setup_test_db(name: &str) -> String {
+    let mut path: PathBuf = env::temp_dir();
+    path.push(format!("{}_rtimelog.sqlite", name));
+    let db_path = path.to_string_lossy().to_string();
+    let _ = std::fs::remove_file(&db_path);
+    db_path
+}
+
+#[test]
+fn test_create_missing_in_when_only_out_exists() {
+    let db_path = setup_test_db("missing_event_in");
+
+    // Init DB
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "--test", "init"])
+        .assert()
+        .success();
+
+    // Create only an OUT event for the date (no start)
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "add", "2025-10-01", "--out", "17:00"])
+        .assert()
+        .success();
+
+    // Verify currently there is a single out event
+    let out_only = Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "--test", "list", "--events", "--json"])
+        .output()
+        .expect("failed to list events (out-only)");
+    assert!(out_only.status.success());
+    let json: Value = serde_json::from_slice(&out_only.stdout).expect("invalid JSON");
+    let arr = json.as_array().expect("expected array");
+    assert_eq!(arr.len(), 1, "Expected exactly 1 event (out only)");
+    assert_eq!(arr[0]["kind"], "out");
+
+    // Now use explicit edit on pair 1 to add the missing IN event
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "add",
+            "2025-10-01",
+            "--edit",
+            "--pair",
+            "1",
+            "--in",
+            "09:00",
+        ])
+        .assert()
+        .success();
+
+    // Re-list events and expect both in and out
+    let both = Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "--test", "list", "--events", "--json"])
+        .output()
+        .expect("failed to list events (after creating in)");
+    assert!(both.status.success());
+    let json2: Value = serde_json::from_slice(&both.stdout).expect("invalid JSON");
+    let arr2 = json2.as_array().expect("expected array");
+
+    // Should now have 2 events
+    assert_eq!(arr2.len(), 2, "Expected 2 events after adding missing in");
+    let in_event = arr2
+        .iter()
+        .find(|e| e["kind"] == "in")
+        .expect("missing in event");
+    let out_event = arr2
+        .iter()
+        .find(|e| e["kind"] == "out")
+        .expect("missing out event");
+
+    assert_eq!(in_event["time"].as_str().unwrap(), "09:00");
+    assert_eq!(out_event["time"].as_str().unwrap(), "17:00");
+}

--- a/tests/update_pair_tests.rs
+++ b/tests/update_pair_tests.rs
@@ -1,0 +1,204 @@
+use assert_cmd::Command;
+use serde_json::Value;
+use std::env;
+use std::path::PathBuf;
+
+/// Create a unique test DB path inside the system temp dir
+fn setup_test_db(name: &str) -> String {
+    let mut path: PathBuf = env::temp_dir();
+    path.push(format!("{}_rtimelog.sqlite", name));
+    let db_path = path.to_string_lossy().to_string();
+    let _ = std::fs::remove_file(&db_path);
+    db_path
+}
+
+#[test]
+fn test_update_does_not_create_new_pair() {
+    let db_path = setup_test_db("update_pair");
+
+    // Init DB
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "--test", "init"])
+        .assert()
+        .success();
+
+    // Add initial full session -> produces exactly 2 events (in/out) with pair=1
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "add",
+            "2025-09-20",
+            "O",
+            "09:00",
+            "30",
+            "17:00",
+        ])
+        .assert()
+        .success();
+
+    // Capture events JSON after initial insert
+    let initial_output = Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "--test", "list", "--events", "--json"])
+        .output()
+        .expect("failed to list events (initial)");
+    assert!(initial_output.status.success());
+    let initial_json: Value =
+        serde_json::from_slice(&initial_output.stdout).expect("invalid JSON initial events");
+    let initial_events = initial_json.as_array().expect("expected array of events");
+    assert_eq!(
+        initial_events.len(),
+        2,
+        "Expected exactly 2 events after first add"
+    );
+
+    let init_in = initial_events
+        .iter()
+        .find(|e| e["kind"] == "in")
+        .expect("missing in event");
+    let init_out = initial_events
+        .iter()
+        .find(|e| e["kind"] == "out")
+        .expect("missing out event");
+
+    let in_id = init_in["id"].as_i64().unwrap();
+    let out_id = init_out["id"].as_i64().unwrap();
+
+    // Update ONLY start time via explicit edit (pair 1)
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "add",
+            "2025-09-20",
+            "--edit",
+            "--pair",
+            "1",
+            "--in",
+            "09:15",
+        ])
+        .assert()
+        .success();
+
+    // Update ONLY end time via explicit edit (pair 1)
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "add",
+            "2025-09-20",
+            "--edit",
+            "--pair",
+            "1",
+            "--out",
+            "17:05",
+        ])
+        .assert()
+        .success();
+
+    // Update ONLY lunch via explicit edit (pair 1)
+    Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args([
+            "--db",
+            &db_path,
+            "add",
+            "2025-09-20",
+            "--edit",
+            "--pair",
+            "1",
+            "--lunch",
+            "45",
+        ])
+        .assert()
+        .success();
+
+    // Re-capture events JSON after updates
+    let final_output = Command::cargo_bin("rtimelog")
+        .unwrap()
+        .args(["--db", &db_path, "--test", "list", "--events", "--json"])
+        .output()
+        .expect("failed to list events (final)");
+    assert!(final_output.status.success());
+    let final_json: Value =
+        serde_json::from_slice(&final_output.stdout).expect("invalid JSON final events");
+    let final_events = final_json.as_array().expect("expected array of events");
+
+    // Still exactly 2 events
+    assert_eq!(
+        final_events.len(),
+        2,
+        "Editing fields must NOT create extra events/pairs"
+    );
+
+    // Fetch updated events
+    let final_in = final_events
+        .iter()
+        .find(|e| e["kind"] == "in")
+        .expect("missing final in event");
+    let final_out = final_events
+        .iter()
+        .find(|e| e["kind"] == "out")
+        .expect("missing final out event");
+
+    // IDs must be unchanged (no insertion of new rows)
+    assert_eq!(
+        final_in["id"].as_i64().unwrap(),
+        in_id,
+        "In event id changed unexpectedly (new event created?)"
+    );
+    assert_eq!(
+        final_out["id"].as_i64().unwrap(),
+        out_id,
+        "Out event id changed unexpectedly (new event created?)"
+    );
+
+    // Times updated
+    assert_eq!(
+        final_in["time"].as_str().unwrap(),
+        "09:15",
+        "Start time not updated in place"
+    );
+    assert_eq!(
+        final_out["time"].as_str().unwrap(),
+        "17:05",
+        "End time not updated in place"
+    );
+
+    // Lunch updated only on out event
+    assert_eq!(
+        final_in["lunch_break"].as_i64().unwrap(),
+        0,
+        "In event lunch should remain 0"
+    );
+    assert_eq!(
+        final_out["lunch_break"].as_i64().unwrap(),
+        45,
+        "Out event lunch not updated"
+    );
+
+    // Pair logic unchanged: both pair=1, unmatched=false
+    assert_eq!(
+        final_in["pair"].as_u64().unwrap(),
+        1,
+        "In event pair id changed"
+    );
+    assert_eq!(
+        final_out["pair"].as_u64().unwrap(),
+        1,
+        "Out event pair id changed"
+    );
+    assert!(
+        !final_in["unmatched"].as_bool().unwrap(),
+        "In event became unmatched unexpectedly"
+    );
+    assert!(
+        !final_out["unmatched"].as_bool().unwrap(),
+        "Out event became unmatched unexpectedly"
+    );
+}


### PR DESCRIPTION
# [0.4.1] - 2025-10-03

### Added

- Unit test(s) targeting the creation of missing events (exposed for unit testing).

### Changed

- Refactored event helper logic:
  - Extracted `create_missing_event` helper into a reusable function and moved it to `src/events.rs` for better testability and separation of concerns.
  - Removed duplicated code in `commands.rs` and consolidated the helper usage.
- Presentation improvement: in `list --events --summary` the Duration field is now displayed in a human-friendly "Xh Ym" format instead of raw minutes (display-only change).
- Updated integration tests to cover the new event creation logic.

### Fixed

- Resolved compilation issues caused by duplicate definitions in `commands.rs`.
