### PR TITLE
V0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - `del <date>` removes all events and legacy work_session rows for the given date (with interactive confirmation).
   - `del --pair <pair> <date>` removes only the events belonging to the specified pair for that date (with interactive confirmation); if no events remain for the date the legacy work_sessions row(s) are removed as well.
 - Database helper functions to delete events by date/ids and sessions by date.
+- `del` now records concise audit entries into the internal `log` table (visible with `rtimelog log --print`).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+# [0.4.2] - 2025-10-03
+
+### Added
+
+- `del` enhancements:
+  - `del <date>` removes all events and legacy work_session rows for the given date (with interactive confirmation).
+  - `del --pair <pair> <date>` removes only the events belonging to the specified pair for that date (with interactive confirmation); if no events remain for the date the legacy work_sessions row(s) are removed as well.
+- Database helper functions to delete events by date/ids and sessions by date.
+
+### Changed
+
+- Introduced position value `M` (Mixed) to indicate days with multiple working positions; updated `describe_position` to display a friendly label for `M`.
+- Extracted `create_missing_event` into `src/events.rs` and added a unit test to improve testability and reduce duplicate code in `commands.rs`.
+- `list --events --summary` now displays Dur in a human-friendly "XH YYM" format; JSON output remains in minutes (`duration_minutes`).
+- Updated README to document the above behavior and examples.
+
+### Fixed
+
+- Added a migration to extend position CHECKs to include `'M'` and to update existing tables where necessary.
+- Fixed a Clippy warning in `db::delete_events_by_ids` (removed an unnecessary map_identity) so `cargo clippy -D warnings` passes.
+- Updated integration tests to verify deletion-by-date and deletion-by-pair behavior.
+
+---
+
 # [0.4.1] - 2025-10-03
 
 ### Added
@@ -26,7 +50,7 @@
 
 - Event pair aggregation features:
   - Derived **Pair** column when listing events (sequential pairing of `in` with next `out` per date, FIFO).
-  - `--pairs <id>` filter to show only events (or summaries) for a specific pair id.
+  - `--pairs <id>` filter to show only events (or summaries) for a specific pair id (per date).
   - `--summary` mode (only with `--events`) to display one aggregated row per pair (start, end, lunch, net duration, unmatched flag).
   - Enriched JSON output (`--events --json` and `--events --summary --json`) including fields: `pair`, `unmatched`, `lunch_minutes`, `duration_minutes` (summary mode).
 - Unmatched event handling: lone `in` or `out` events are marked with an asterisk (`*`) after the pair id and `"unmatched": true` in JSON.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,7 +439,7 @@ dependencies = [
 
 [[package]]
 name = "r_timelog"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "r_timelog"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 authors = ["Umpire274 <umpire274@gmail.com>"]
 description = "A simple cross-platform CLI tool to track working hours, lunch breaks, and calculate surplus time"

--- a/README.md
+++ b/README.md
@@ -10,33 +10,22 @@ The tool calculates the expected exit time and the surplus of worked minutes.
 
 ---
 
-## What's new in v0.4.1
+## What's new in v0.4.2
 
-**Refactor, fixes and display improvements**
+**Delete-by-date/pair, mixed position and quality fixes**
 
-This micro-release cleans up duplicated code, improves testability and the user-facing duration format:
+This release brings safer deletion primitives, a new mixed position flag and a number of internal cleanups:
 
-- Refactored: extracted the `create_missing_event` helper into `src/events.rs` to make it reusable and easier to
-  unit-test.
-- Fixed: removed duplicated logic from `commands.rs` that caused compile-time errors, and consolidated event creation
-  paths.
-- Tests: added a focused unit test covering creation of missing events (now easier to test because the helper is exposed
-  to the events module).
-- Display: in `rtimelog list --events --summary` the `Dur` column is now shown as human-friendly hours/minutes (for
-  example `2h 30m`) instead of raw minutes. This is a presentation-only change; JSON output and internal representations
-  still use integer minutes (`duration_minutes`).
-- Cleanup: removed temporary tracking of `commit_msg.txt` and ensured commit messages are kept in English.
-
-```bash
-# Detailed events (raw punches)
-rtimelog list --events
-
-# Summarized per pair (start/end/lunch/duration, human-friendly Dur)
-rtimelog list --events --summary
-
-# JSON summary (durations still in minutes)
-rtimelog list --events --summary --json
-```
+- New deletion mode:
+    - `del <date>` deletes all events and legacy `work_sessions` rows for the given date (interactive confirmation).
+    - `del --pair <pair> <date>` deletes only events belonging to the given pair for that date (interactive
+      confirmation). If no events remain for the date the legacy `work_sessions` row(s) are removed as well.
+- Database: introduced position value `M` (Mixed) to mark days with multiple positions and added a migration to extend
+  the CHECK constraints.
+- Code: extracted `create_missing_event` helper into `src/events.rs` (unit-tested) and removed duplicated logic from
+  `commands.rs`.
+- Tests: integration tests added/updated to cover deletion-by-date and deletion-by-pair behavior.
+- Lint: fixed a Clippy warning to allow `cargo clippy -D warnings` to pass.
 
 ### Sample (summary mode)
 
@@ -203,10 +192,18 @@ rtimelog list --events --summary --pairs 1
 rtimelog list --events --summary --json
 ```
 
-### Delete a session by id
+### Delete a session by date
 
 ```bash
-rtimelog del 1
+# Delete all records for a date (confirmation required)
+rtimelog del 2025-10-02
+```
+
+### Delete a specific pair for a specific date
+
+```bash
+# Delete only pair 1 for a specific date (confirmation required)
+rtimelog del --pair 1 2025-10-02
 ```
 
 ### Internal log

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -187,8 +187,37 @@ pub fn handle_del(cmd: &Commands, conn: &Connection) -> rusqlite::Result<()> {
                             "del",
                             &format!("Deleted work_sessions for date={}", date),
                         );
-                    } else if let Ok(Some(agg)) = db::aggregate_position_from_events(conn, date) {
-                        let _ = db::force_set_position(conn, date, &agg);
+                    } else {
+                        // 1) Set end_time in work_sessions to the highest time among remaining events
+                        if let Some(max_time) = remaining.iter().map(|e| e.time.clone()).max() {
+                            let _ = db::force_set_end(conn, date, &max_time);
+                            println!(
+                                "⏱️  Updated work_sessions end_time to {} for {}",
+                                max_time, date
+                            );
+                            let _ = db::ttlog(
+                                conn,
+                                "del",
+                                &format!("Updated end_time={} for date={}", max_time, date),
+                            );
+                        }
+
+                        // 2) If all remaining events share the same position, set work_sessions.position to it.
+                        //    If positions are mixed, do not change the stored position.
+                        let mut positions: Vec<String> =
+                            remaining.iter().map(|e| e.position.clone()).collect();
+                        positions.sort();
+                        positions.dedup();
+                        if positions.len() == 1 {
+                            let pos = &positions[0];
+                            let _ = db::force_set_position(conn, date, pos);
+                            println!("📌 Updated work_sessions position to {} for {}", pos, date);
+                            let _ = db::ttlog(
+                                conn,
+                                "del",
+                                &format!("Updated position={} for date={}", pos, date),
+                            );
+                        }
                     }
                 }
                 Err(e) => eprintln!("❌ Error deleting pair events: {}", e),

--- a/src/db.rs
+++ b/src/db.rs
@@ -624,9 +624,8 @@ pub fn delete_events_by_ids_and_recompute_sessions(
         sql.push(')');
         let params_vec: Vec<&dyn ToSql> = ids.iter().map(|i| i as &dyn ToSql).collect();
         let mut del_stmt = tx.prepare(&sql)?;
-        let changed = del_stmt.execute(rusqlite::params_from_iter(params_vec))?;
-        // del_stmt dropped here at end of scope
-        changed
+
+        del_stmt.execute(rusqlite::params_from_iter(params_vec))?
     };
 
     // Query remaining events for the date inside the same transaction; keep statement scoped

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,8 +95,12 @@ enum Commands {
     },
     /// Delete a work session by ID
     Del {
-        /// ID of the session to delete
-        id: i32,
+        /// Optional pair id to delete (use with date): deletes only the given pair for the date
+        #[arg(long = "pair", help = "Pair id to delete for the given date")]
+        pair: Option<usize>,
+
+        /// Date (YYYY-MM-DD) to delete (all sessions/events for this date) or required with --pair
+        date: String,
     },
     /// List sessions
     List {

--- a/src/main.rs
+++ b/src/main.rs
@@ -210,7 +210,7 @@ fn main() -> rusqlite::Result<()> {
 
     match &cli.command {
         Commands::Add { .. } => commands::handle_add(&cli.command, &mut conn, &config)?,
-        Commands::Del { .. } => commands::handle_del(&cli.command, &conn)?,
+        Commands::Del { .. } => commands::handle_del(&cli.command, &mut conn)?,
         Commands::List {
             period,
             pos,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -96,6 +96,11 @@ pub fn describe_position(pos: &str) -> (String, String) {
             let colored = "\x1b[45;97;1m".to_string();
             (label, colored)
         }
+        "M" => {
+            let label = "Mixed".to_string();
+            let colored = "\x1b[35m".to_string(); // magenta
+            (label, colored)
+        }
         _ => {
             let label = pos.to_string();
             (label.clone(), "\x1b[0m".to_string()) // fallback senza colore


### PR DESCRIPTION
# [0.4.2] - 2025-10-03

### Added

- `del` enhancements:
  - `del <date>` removes all events and legacy work_session rows for the given date (with interactive confirmation).
  - `del --pair <pair> <date>` removes only the events belonging to the specified pair for that date (with interactive confirmation); if no events remain for the date the legacy work_sessions row(s) are removed as well.
- Database helper functions to delete events by date/ids and sessions by date.
- `del` now records concise audit entries into the internal `log` table (visible with `rtimelog log --print`).

### Changed

- Introduced position value `M` (Mixed) to indicate days with multiple working positions; updated `describe_position` to display a friendly label for `M`.
- Extracted `create_missing_event` into `src/events.rs` and added a unit test to improve testability and reduce duplicate code in `commands.rs`.
- `list --events --summary` now displays Dur in a human-friendly "XH YYM" format; JSON output remains in minutes (`duration_minutes`).
- Updated README to document the above behavior and examples.

### Fixed

- Added a migration to extend position CHECKs to include `'M'` and to update existing tables where necessary.
- Fixed a Clippy warning in `db::delete_events_by_ids` (removed an unnecessary map_identity) so `cargo clippy -D warnings` passes.
- Updated integration tests to verify deletion-by-date and deletion-by-pair behavior.

